### PR TITLE
[feat] feat/001-01-dependency-and-config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,11 @@ out/
 
 ### Kotlin ###
 .kotlin
+
+### macOS ###
+.DS_Store
+*.swp
+*~
+
+### Environment ###
+.env

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
 	kotlin("jvm") version "1.9.25"
 	kotlin("plugin.spring") version "1.9.25"
+	kotlin("plugin.jpa") version "1.9.25"
 	id("org.springframework.boot") version "3.5.11"
 	id("io.spring.dependency-management") version "1.1.7"
 }
@@ -20,15 +21,19 @@ repositories {
 }
 
 dependencies {
-//	implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
+	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16")
+	implementation("org.flywaydb:flyway-core")
+	implementation("org.flywaydb:flyway-mysql")
+	runtimeOnly("com.mysql:mysql-connector-j")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
-//	testImplementation("org.springframework.boot:spring-boot-testcontainers")
+	testImplementation("org.springframework.boot:spring-boot-testcontainers")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testImplementation("org.testcontainers:junit-jupiter")
+	testImplementation("org.testcontainers:mysql")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: foreign_api_sample_mysql
+    ports:
+      - "${MYSQL_PORT}:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    volumes:
+      - mysql_data:/var/lib/mysql
+
+volumes:
+  mysql_data:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,22 @@
 spring:
   application:
     name: foreign_api_sample
+
+  datasource:
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO}
+    show-sql: ${SPRING_JPA_SHOW_SQL}
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+
+  flyway:
+    enabled: true
+    locations: classpath:db/migration

--- a/src/test/kotlin/org/sampletask/foreign_api_sample/TestcontainersConfiguration.kt
+++ b/src/test/kotlin/org/sampletask/foreign_api_sample/TestcontainersConfiguration.kt
@@ -1,6 +1,17 @@
 package org.sampletask.foreign_api_sample
 
 import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection
+import org.springframework.context.annotation.Bean
+import org.testcontainers.containers.MySQLContainer
 
 @TestConfiguration(proxyBeanMethods = false)
-class TestcontainersConfiguration
+class TestcontainersConfiguration {
+
+    @Bean
+    @ServiceConnection
+    fun mysqlContainer(): MySQLContainer<*> {
+        return MySQLContainer("mysql:8.0")
+            .withDatabaseName("foreign_api_sample")
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:tc:mysql:8.0:///foreign_api_sample
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+
+  flyway:
+    enabled: true
+    locations: classpath:db/migration


### PR DESCRIPTION
## Summary

Closes #2

### 변경 사항
- **build.gradle.kts**: Spring Data JPA, Flyway, mysql-connector-j, Testcontainers MySQL 의존성 추가
- **application.yaml**: datasource/JPA/Flyway 설정을 환경변수(`${SPRING_DATASOURCE_URL}` 등)로 외부화
- **docker-compose.yml** (신규): MySQL 8.0 컨테이너 정의, `.env` 파일 기반 환경변수 참조
- **TestcontainersConfiguration.kt**: MySQL Testcontainer Bean 추가
- **application-test.yaml** (신규): Testcontainers JDBC 드라이버 기반 테스트 설정
- **.gitignore**: `.env`, macOS 관련 패턴 추가
- **claude.md, readme.md**: 에이전트 규칙 마크다운 추가, 프로젝트 가이드 마크다운 개편

### 참고
- `.env` 파일은 `.gitignore`에 포함되어 커밋되지 않음
- 모든 DB 계정/비밀번호는 로컬 개발용 `test`로 통일

## Test plan
- [x] `docker-compose up -d` → MySQL 컨테이너 정상 구동 확인
- [x] `docker exec`로 `test` 계정 DB 접속 확인
- [x] `./gradlew build -x test` 빌드 성공 확인