### PR TITLE
[feat] feat/003-01-exception-domain

### DIFF
--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/domain/Task.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/domain/Task.kt
@@ -1,5 +1,6 @@
 package org.sampletask.foreign_api_sample.task.domain
 
+import org.sampletask.foreign_api_sample.task.exception.InvalidTaskStateException
 import java.time.Instant
 
 class Task(
@@ -18,7 +19,7 @@ class Task(
 ) {
 	fun transitionTo(taskStatus: TaskStatus) {
 		if (!status.canTransitionTo(taskStatus)) {
-			throw IllegalStateException("Cannot transition from $status to $taskStatus")
+			throw InvalidTaskStateException(status, taskStatus)
 		}
 		status = taskStatus
 		updatedAt = Instant.now()

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/domain/TaskStatus.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/domain/TaskStatus.kt
@@ -11,7 +11,7 @@ enum class TaskStatus(val code: Int) {
 	fun canTransitionTo(target: TaskStatus): Boolean {
 		return when (this) {
 			PENDING -> target in listOf(PROCESSING, CANCELLED)
-			PROCESSING -> target in listOf(COMPLETED, FAILED, CANCELLED)
+			PROCESSING -> target in listOf(COMPLETED, FAILED, CANCELLED, PENDING) // PENDING 복귀는 recovery 전용
 			FAILED -> target == PENDING // 재시도 시 PENDING으로 복귀
 			COMPLETED, CANCELLED -> false
 		}

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/entity/TaskEntity.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/entity/TaskEntity.kt
@@ -50,5 +50,5 @@ class TaskEntity(
 	var updatedAt: Instant = Instant.now(),
 
 	@Version
-	val version: Long = 0,
+	var version: Long = 0,
 )

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/exception/ApiKeyUnavailableException.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/exception/ApiKeyUnavailableException.kt
@@ -1,0 +1,10 @@
+package org.sampletask.foreign_api_sample.task.exception
+
+import org.springframework.http.HttpStatus
+
+class ApiKeyUnavailableException(msg: String) :
+	SystemException(
+		httpStatus = HttpStatus.SERVICE_UNAVAILABLE,
+		errorCode = "API_KEY_UNAVAILABLE",
+		message = msg,
+	)

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/exception/BusinessException.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/exception/BusinessException.kt
@@ -1,0 +1,9 @@
+package org.sampletask.foreign_api_sample.task.exception
+
+import org.springframework.http.HttpStatus
+
+sealed class BusinessException(
+	val httpStatus: HttpStatus,
+	val errorCode: String,
+	override val message: String,
+) : RuntimeException(message)

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/exception/IdempotencyKeyConflictException.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/exception/IdempotencyKeyConflictException.kt
@@ -1,0 +1,10 @@
+package org.sampletask.foreign_api_sample.task.exception
+
+import org.springframework.http.HttpStatus
+
+class IdempotencyKeyConflictException(val idempotencyKey: String) :
+	BusinessException(
+		httpStatus = HttpStatus.CONFLICT,
+		errorCode = "IDEMPOTENCY_KEY_CONFLICT",
+		message = "Idempotency key conflict: $idempotencyKey",
+	)

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/exception/InvalidTaskStateException.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/exception/InvalidTaskStateException.kt
@@ -1,0 +1,13 @@
+package org.sampletask.foreign_api_sample.task.exception
+
+import org.sampletask.foreign_api_sample.task.domain.TaskStatus
+import org.springframework.http.HttpStatus
+
+class InvalidTaskStateException(
+	val currentStatus: TaskStatus,
+	val attemptedStatus: TaskStatus,
+) : BusinessException(
+	httpStatus = HttpStatus.CONFLICT,
+	errorCode = "INVALID_TASK_STATE",
+	message = "Cannot transition from $currentStatus to $attemptedStatus",
+)

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/exception/MockWorkerException.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/exception/MockWorkerException.kt
@@ -1,0 +1,13 @@
+package org.sampletask.foreign_api_sample.task.exception
+
+import org.springframework.http.HttpStatus
+
+class MockWorkerException(
+	val upstreamHttpStatus: Int,
+	val errorBody: String?,
+	val isTransient: Boolean,
+) : SystemException(
+	httpStatus = HttpStatus.BAD_GATEWAY,
+	errorCode = "EXTERNAL_SERVICE_ERROR",
+	message = "Mock Worker error: HTTP $upstreamHttpStatus${if (errorBody != null) " - $errorBody" else ""}",
+)

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/exception/SystemException.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/exception/SystemException.kt
@@ -1,0 +1,9 @@
+package org.sampletask.foreign_api_sample.task.exception
+
+import org.springframework.http.HttpStatus
+
+sealed class SystemException(
+	val httpStatus: HttpStatus,
+	val errorCode: String,
+	override val message: String,
+) : RuntimeException(message)

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/exception/TaskNotFoundException.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/exception/TaskNotFoundException.kt
@@ -1,0 +1,10 @@
+package org.sampletask.foreign_api_sample.task.exception
+
+import org.springframework.http.HttpStatus
+
+class TaskNotFoundException(val taskId: Long) :
+	BusinessException(
+		httpStatus = HttpStatus.NOT_FOUND,
+		errorCode = "TASK_NOT_FOUND",
+		message = "Task not found: $taskId",
+	)

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/repository/TaskRepository.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/repository/TaskRepository.kt
@@ -1,6 +1,15 @@
 package org.sampletask.foreign_api_sample.task.repository
 
 import org.sampletask.foreign_api_sample.task.entity.TaskEntity
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import java.time.Instant
 
-interface TaskRepository : JpaRepository<TaskEntity, Long>
+interface TaskRepository : JpaRepository<TaskEntity, Long> {
+	fun findByIdempotencyKeyAndCreatedAtAfter(idempotencyKey: String, cutoff: Instant): TaskEntity?
+
+	fun findByStatus(status: Int, pageable: Pageable): Page<TaskEntity>
+
+	fun findAllByStatusIn(statuses: List<Int>): List<TaskEntity>
+}


### PR DESCRIPTION
## Summary
- sealed class 기반 Business/System 예외 계층 구조 정의
- Task 도메인 모델 보강 (상태 전이 메서드, 타임스탬프 관리)
- TaskStatus 상태 머신 구현 (5개 상태, 전이 규칙 검증)
- TaskEntity JPA 매핑 및 Entity↔Domain 변환
- TaskRepository 커스텀 쿼리 추가 (멱등성 키, 상태별, 복구용)

Closes #24