### PR TITLE
[feat] feat/003-02-api-client

### DIFF
--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/client/ApiKeyManager.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/client/ApiKeyManager.kt
@@ -1,0 +1,86 @@
+package org.sampletask.foreign_api_sample.task.client
+
+import org.sampletask.foreign_api_sample.task.client.dto.IssueKeyRequest
+import org.sampletask.foreign_api_sample.task.client.dto.IssueKeyResponse
+import org.sampletask.foreign_api_sample.task.exception.ApiKeyUnavailableException
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.awaitBody
+import java.util.concurrent.atomic.AtomicBoolean
+
+@Component
+class ApiKeyManager(
+	private val webClient: WebClient,
+	@Value("\${mock-worker.auth.candidate-name}") private val candidateName: String,
+	@Value("\${mock-worker.auth.email}") private val email: String,
+) {
+	private val log = LoggerFactory.getLogger(javaClass)
+
+	@Volatile
+	private var _apiKey: String? = null
+	val apiKey: String? get() = _apiKey
+
+	private val reissueLock = AtomicBoolean(false)
+
+	@EventListener(ApplicationReadyEvent::class)
+	fun onApplicationReady() {
+		try {
+			kotlinx.coroutines.runBlocking { issueApiKey() }
+		} catch (e: Exception) {
+			log.warn("서버 시작 시 API Key 발급 실패 - 첫 요청 시 재시도합니다: {}", e.message)
+		}
+	}
+
+	suspend fun getApiKey(): String {
+		return apiKey ?: run {
+			reissueApiKey()
+			apiKey ?: throw ApiKeyUnavailableException("API Key를 발급받을 수 없습니다")
+		}
+	}
+
+	suspend fun reissueApiKey() {
+		if (!reissueLock.compareAndSet(false, true)) {
+			log.debug("API Key 재발급이 이미 진행 중입니다")
+			return
+		}
+
+		try {
+			repeat(MAX_REISSUE_ATTEMPTS) { attempt ->
+				try {
+					issueApiKey()
+					log.info("API Key 재발급 성공 (시도: {})", attempt + 1)
+					return
+				} catch (e: Exception) {
+					log.warn("API Key 재발급 실패 (시도: {}): {}", attempt + 1, e.message)
+					if (attempt == MAX_REISSUE_ATTEMPTS - 1) {
+						throw ApiKeyUnavailableException(
+							"API Key 재발급 실패 (${MAX_REISSUE_ATTEMPTS}회 시도): ${e.message}",
+						)
+					}
+				}
+			}
+		} finally {
+			reissueLock.set(false)
+		}
+	}
+
+	private suspend fun issueApiKey() {
+		val response =
+			webClient
+				.post()
+				.uri("/mock/auth/issue-key")
+				.bodyValue(IssueKeyRequest(candidateName, email))
+				.retrieve()
+				.awaitBody<IssueKeyResponse>()
+
+		_apiKey = response.apiKey
+	}
+
+	companion object {
+		private const val MAX_REISSUE_ATTEMPTS = 3
+	}
+}

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/client/MockWorkerClient.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/client/MockWorkerClient.kt
@@ -1,0 +1,97 @@
+package org.sampletask.foreign_api_sample.task.client
+
+import io.github.resilience4j.bulkhead.BulkheadRegistry
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import io.github.resilience4j.kotlin.bulkhead.executeSuspendFunction
+import io.github.resilience4j.kotlin.circuitbreaker.executeSuspendFunction
+import io.github.resilience4j.kotlin.ratelimiter.executeSuspendFunction
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry
+import org.sampletask.foreign_api_sample.task.client.dto.JobStatusResponse
+import org.sampletask.foreign_api_sample.task.client.dto.ProcessRequest
+import org.sampletask.foreign_api_sample.task.client.dto.ProcessResponse
+import org.sampletask.foreign_api_sample.task.exception.MockWorkerException
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatusCode
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.web.reactive.function.client.awaitBody
+
+@Component
+class MockWorkerClient(
+	private val webClient: WebClient,
+	private val apiKeyManager: ApiKeyManager,
+	circuitBreakerRegistry: CircuitBreakerRegistry,
+	rateLimiterRegistry: RateLimiterRegistry,
+	bulkheadRegistry: BulkheadRegistry,
+) {
+	private val log = LoggerFactory.getLogger(javaClass)
+	private val circuitBreaker = circuitBreakerRegistry.circuitBreaker("mock-worker")
+	private val rateLimiter = rateLimiterRegistry.rateLimiter("mock-worker")
+	private val bulkhead = bulkheadRegistry.bulkhead("mock-worker")
+
+	suspend fun submitProcess(imageUrl: String): ProcessResponse {
+		return withResilience {
+			executeWithAuthRetry {
+				webClient
+					.post()
+					.uri("/mock/process")
+					.header("X-Api-Key", apiKeyManager.getApiKey())
+					.bodyValue(ProcessRequest(imageUrl))
+					.retrieve()
+					.awaitBody<ProcessResponse>()
+			}
+		}
+	}
+
+	suspend fun getJobStatus(jobId: String): JobStatusResponse {
+		return withResilience {
+			executeWithAuthRetry {
+				webClient
+					.get()
+					.uri("/mock/process/{jobId}", jobId)
+					.header("X-Api-Key", apiKeyManager.getApiKey())
+					.retrieve()
+					.awaitBody<JobStatusResponse>()
+			}
+		}
+	}
+
+	private suspend fun <T> withResilience(block: suspend () -> T): T {
+		return circuitBreaker.executeSuspendFunction {
+			rateLimiter.executeSuspendFunction {
+				bulkhead.executeSuspendFunction {
+					block()
+				}
+			}
+		}
+	}
+
+	private suspend fun <T> executeWithAuthRetry(block: suspend () -> T): T {
+		return try {
+			block()
+		} catch (e: WebClientResponseException) {
+			if (e.statusCode == HttpStatusCode.valueOf(401)) {
+				log.info("401 응답 수신 - API Key 재발급 후 재시도")
+				apiKeyManager.reissueApiKey()
+				try {
+					block()
+				} catch (retryEx: WebClientResponseException) {
+					throw toMockWorkerException(retryEx)
+				}
+			} else {
+				throw toMockWorkerException(e)
+			}
+		}
+	}
+
+	private fun toMockWorkerException(e: WebClientResponseException): MockWorkerException {
+		val statusCode = e.statusCode.value()
+		val isTransient = statusCode in listOf(429, 500, 502, 503, 504)
+		return MockWorkerException(
+			upstreamHttpStatus = statusCode,
+			errorBody = e.responseBodyAsString,
+			isTransient = isTransient,
+		)
+	}
+}

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/client/dto/IssueKeyRequest.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/client/dto/IssueKeyRequest.kt
@@ -1,0 +1,6 @@
+package org.sampletask.foreign_api_sample.task.client.dto
+
+data class IssueKeyRequest(
+	val candidateName: String,
+	val email: String,
+)

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/client/dto/IssueKeyResponse.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/client/dto/IssueKeyResponse.kt
@@ -1,0 +1,5 @@
+package org.sampletask.foreign_api_sample.task.client.dto
+
+data class IssueKeyResponse(
+	val apiKey: String,
+)

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/client/dto/JobStatusResponse.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/client/dto/JobStatusResponse.kt
@@ -1,0 +1,9 @@
+package org.sampletask.foreign_api_sample.task.client.dto
+
+data class JobStatusResponse(
+	val jobId: String,
+	val status: String,
+	val result: String? = null,
+	val errorCode: String? = null,
+	val errorMessage: String? = null,
+)

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/client/dto/ProcessRequest.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/client/dto/ProcessRequest.kt
@@ -1,0 +1,5 @@
+package org.sampletask.foreign_api_sample.task.client.dto
+
+data class ProcessRequest(
+	val imageUrl: String,
+)

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/client/dto/ProcessResponse.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/client/dto/ProcessResponse.kt
@@ -1,0 +1,5 @@
+package org.sampletask.foreign_api_sample.task.client.dto
+
+data class ProcessResponse(
+	val jobId: String,
+)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -33,6 +33,9 @@ mock-worker:
     connect-ms: 5000
     read-ms: 10000
     write-ms: 10000
+  auth:
+    candidate-name: ${MOCK_WORKER_CANDIDATE_NAME}
+    email: ${MOCK_WORKER_EMAIL}
 
 resilience4j:
   circuitbreaker:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -18,3 +18,6 @@ spring:
 
 mock-worker:
   base-url: http://localhost:8089
+  auth:
+    candidate-name: test-candidate
+    email: test@example.com


### PR DESCRIPTION
## Summary
- ApiKeyManager 구현 (지연 발급, 캐싱, 재발급 retry)
- MockWorkerClient 구현 (submitProcess, getJobStatus)
- Resilience4j 적용 (CircuitBreaker, RateLimiter, Bulkhead 조합)
- 401 응답 시 API 키 재발급 및 자동 재시도 로직
- Client DTO 정의 (IssueKey, Process, JobStatus 요청/응답)
- application.yaml mock-worker.auth 설정 추가

Closes #25