### PR TITLE
[feat] feat/003-03-service-layer

### DIFF
--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestrator.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestrator.kt
@@ -1,0 +1,130 @@
+package org.sampletask.foreign_api_sample.task.service
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.sampletask.foreign_api_sample.task.client.MockWorkerClient
+import org.sampletask.foreign_api_sample.task.domain.Task
+import org.sampletask.foreign_api_sample.task.domain.TaskStatus
+import org.sampletask.foreign_api_sample.task.exception.MockWorkerException
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class TaskOrchestrator(
+	private val taskService: TaskService,
+	private val mockWorkerClient: MockWorkerClient,
+	private val scope: CoroutineScope,
+	@Value("\${task.max-retry-count:3}") private val maxRetryCount: Int,
+	@Value("\${task.polling.initial-interval-ms:2000}") private val initialIntervalMs: Long,
+	@Value("\${task.polling.max-interval-ms:10000}") private val maxIntervalMs: Long,
+) {
+	private val log = LoggerFactory.getLogger(javaClass)
+
+	fun submitAsync(task: Task) {
+		scope.launch {
+			processTask(task)
+		}
+	}
+
+	suspend fun processTask(task: Task) {
+		val taskId = task.id
+		try {
+			var current = taskService.getTask(taskId)
+			if (current.status != TaskStatus.PENDING) {
+				log.debug("작업 {} 이미 {} 상태 - 처리 건너뜀", taskId, current.status)
+				return
+			}
+
+			current.transitionTo(TaskStatus.PROCESSING)
+			current = taskService.updateTask(current)
+
+			val processResponse = mockWorkerClient.submitProcess(current.imageUrl)
+			current.externalJobId = processResponse.jobId
+			current = taskService.updateTask(current)
+
+			pollForResult(current)
+		} catch (e: MockWorkerException) {
+			handleError(taskId, e)
+		} catch (e: Exception) {
+			log.error("작업 {} 처리 중 예상치 못한 오류: {}", taskId, e.message, e)
+			failTask(taskId, "INTERNAL_ERROR", e.message)
+		}
+	}
+
+	private suspend fun pollForResult(task: Task) {
+		val jobId = task.externalJobId ?: return
+		val taskId = task.id
+		var intervalMs = initialIntervalMs
+
+		while (true) {
+			delay(intervalMs)
+
+			try {
+				val status = mockWorkerClient.getJobStatus(jobId)
+
+				when (status.status) {
+					"COMPLETED" -> {
+						val current = taskService.getTask(taskId)
+						current.result = status.result
+						current.transitionTo(TaskStatus.COMPLETED)
+						taskService.updateTask(current)
+						log.info("작업 {} 완료", taskId)
+						return
+					}
+					"FAILED" -> {
+						failTask(taskId, status.errorCode, status.errorMessage)
+						return
+					}
+					else -> {
+						intervalMs = (intervalMs * 2).coerceAtMost(maxIntervalMs)
+					}
+				}
+			} catch (e: MockWorkerException) {
+				if (e.upstreamHttpStatus == 404) {
+					log.warn("작업 {} 의 외부 Job {} 이 404 반환 - PENDING 복귀", taskId, jobId)
+					val current = taskService.getTask(taskId)
+					current.externalJobId = null
+					current.transitionTo(TaskStatus.PENDING)
+					val updated = taskService.updateTask(current)
+					submitAsync(updated)
+					return
+				}
+				handleError(taskId, e)
+				return
+			}
+		}
+	}
+
+	private fun handleError(taskId: Long, e: MockWorkerException) {
+		var current = taskService.getTask(taskId)
+		if (e.isTransient && current.retryCount < maxRetryCount) {
+			current.retryCount++
+			current.transitionTo(TaskStatus.FAILED)
+			current = taskService.updateTask(current)
+			log.warn("작업 {} 일시적 오류 (재시도 {}/{}): {}", taskId, current.retryCount, maxRetryCount, e.message)
+
+			current.transitionTo(TaskStatus.PENDING)
+			current = taskService.updateTask(current)
+			submitAsync(current)
+		} else {
+			failTask(taskId, "HTTP_${e.upstreamHttpStatus}", e.errorBody)
+		}
+	}
+
+	private fun failTask(taskId: Long, errorCode: String?, errorMessage: String?) {
+		try {
+			val current = taskService.getTask(taskId)
+			current.errorCode = errorCode
+			current.errorMessage = errorMessage
+			if (current.status != TaskStatus.FAILED) {
+				current.transitionTo(TaskStatus.FAILED)
+			}
+			taskService.updateTask(current)
+			log.error("작업 {} 최종 실패: {} - {}", taskId, errorCode, errorMessage)
+		} catch (e: Exception) {
+			log.error("작업 {} 실패 상태 저장 중 오류: {}", taskId, e.message)
+		}
+	}
+}

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/service/TaskRecoveryService.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/service/TaskRecoveryService.kt
@@ -1,0 +1,98 @@
+package org.sampletask.foreign_api_sample.task.service
+
+import kotlinx.coroutines.runBlocking
+import org.sampletask.foreign_api_sample.task.client.MockWorkerClient
+import org.sampletask.foreign_api_sample.task.domain.TaskStatus
+import org.sampletask.foreign_api_sample.task.entity.mapper.TaskMapper
+import org.sampletask.foreign_api_sample.task.exception.MockWorkerException
+import org.sampletask.foreign_api_sample.task.repository.TaskRepository
+import org.slf4j.LoggerFactory
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class TaskRecoveryService(
+	private val taskRepository: TaskRepository,
+	private val taskService: TaskService,
+	private val taskOrchestrator: TaskOrchestrator,
+	private val mockWorkerClient: MockWorkerClient,
+) {
+	private val log = LoggerFactory.getLogger(javaClass)
+
+	@EventListener(ApplicationReadyEvent::class)
+	fun recoverTasks() {
+		val processingAndPending =
+			taskRepository.findAllByStatusIn(
+				listOf(TaskStatus.PROCESSING.code, TaskStatus.PENDING.code),
+			)
+
+		if (processingAndPending.isEmpty()) {
+			log.info("복구 대상 작업 없음")
+			return
+		}
+
+		log.info("복구 대상 작업 {}건 발견", processingAndPending.size)
+
+		processingAndPending.forEach { entity ->
+			val task = TaskMapper.toDomain(entity)
+
+			when (task.status) {
+				TaskStatus.PROCESSING -> recoverProcessingTask(task)
+				TaskStatus.PENDING -> {
+					log.info("PENDING 작업 {} 재등록", task.id)
+					taskOrchestrator.submitAsync(task)
+				}
+				else -> {}
+			}
+		}
+	}
+
+	private fun recoverProcessingTask(task: org.sampletask.foreign_api_sample.task.domain.Task) {
+		if (task.externalJobId != null) {
+			try {
+				runBlocking {
+					val status = mockWorkerClient.getJobStatus(task.externalJobId!!)
+					when (status.status) {
+						"COMPLETED" -> {
+							task.result = status.result
+							task.transitionTo(TaskStatus.COMPLETED)
+							taskService.updateTask(task)
+							log.info("PROCESSING 작업 {} 외부 상태 확인 → COMPLETED", task.id)
+						}
+						"FAILED" -> {
+							task.errorCode = status.errorCode
+							task.errorMessage = status.errorMessage
+							task.transitionTo(TaskStatus.FAILED)
+							taskService.updateTask(task)
+							log.info("PROCESSING 작업 {} 외부 상태 확인 → FAILED", task.id)
+						}
+						else -> {
+							log.info("PROCESSING 작업 {} 외부 상태 {} - 폴링 재개", task.id, status.status)
+							taskOrchestrator.submitAsync(task)
+						}
+					}
+				}
+			} catch (e: MockWorkerException) {
+				if (e.upstreamHttpStatus == 404) {
+					log.warn("작업 {} 의 외부 Job 404 - PENDING 복귀", task.id)
+					task.externalJobId = null
+					task.transitionTo(TaskStatus.PENDING)
+					taskService.updateTask(task)
+					taskOrchestrator.submitAsync(task)
+				} else {
+					log.error("작업 {} 복구 중 오류: {}", task.id, e.message)
+					taskOrchestrator.submitAsync(task)
+				}
+			} catch (e: Exception) {
+				log.error("작업 {} 복구 중 예상치 못한 오류: {}", task.id, e.message, e)
+				taskOrchestrator.submitAsync(task)
+			}
+		} else {
+			log.info("PROCESSING 작업 {} 에 jobId 없음 - PENDING 복귀", task.id)
+			task.transitionTo(TaskStatus.PENDING)
+			taskService.updateTask(task)
+			taskOrchestrator.submitAsync(task)
+		}
+	}
+}

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/service/TaskService.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/service/TaskService.kt
@@ -1,0 +1,93 @@
+package org.sampletask.foreign_api_sample.task.service
+
+import org.sampletask.foreign_api_sample.task.domain.Task
+import org.sampletask.foreign_api_sample.task.domain.TaskStatus
+import org.sampletask.foreign_api_sample.task.entity.mapper.TaskMapper
+import org.sampletask.foreign_api_sample.task.exception.IdempotencyKeyConflictException
+import org.sampletask.foreign_api_sample.task.exception.TaskNotFoundException
+import org.sampletask.foreign_api_sample.task.repository.TaskRepository
+import org.slf4j.LoggerFactory
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+@Service
+@Transactional
+class TaskService(
+	private val taskRepository: TaskRepository,
+) {
+	private val log = LoggerFactory.getLogger(javaClass)
+
+	fun createTask(idempotencyKey: String, imageUrl: String): Task {
+		val cutoff = Instant.now().minus(IDEMPOTENCY_EXPIRY_HOURS, ChronoUnit.HOURS)
+		val existing = taskRepository.findByIdempotencyKeyAndCreatedAtAfter(idempotencyKey, cutoff)
+
+		if (existing != null) {
+			log.debug("멱등성 키 {} 로 기존 작업 반환: {}", idempotencyKey, existing.id)
+			return TaskMapper.toDomain(existing)
+		}
+
+		val task =
+			Task(
+				idempotencyKey = idempotencyKey,
+				imageUrl = imageUrl,
+			)
+
+		return try {
+			val saved = taskRepository.save(TaskMapper.toEntity(task))
+			TaskMapper.toDomain(saved)
+		} catch (e: DataIntegrityViolationException) {
+			// UNIQUE 제약 위반 race condition 대응
+			val raceWinner = taskRepository.findByIdempotencyKeyAndCreatedAtAfter(idempotencyKey, cutoff)
+			if (raceWinner != null) {
+				TaskMapper.toDomain(raceWinner)
+			} else {
+				throw IdempotencyKeyConflictException(idempotencyKey)
+			}
+		}
+	}
+
+	@Transactional(readOnly = true)
+	fun getTask(taskId: Long): Task {
+		val entity =
+			taskRepository.findById(taskId)
+				.orElseThrow { TaskNotFoundException(taskId) }
+		return TaskMapper.toDomain(entity)
+	}
+
+	@Transactional(readOnly = true)
+	fun listTasks(status: TaskStatus?, pageable: Pageable): Page<Task> {
+		val page =
+			if (status != null) {
+				taskRepository.findByStatus(status.code, pageable)
+			} else {
+				taskRepository.findAll(pageable)
+			}
+		return page.map { TaskMapper.toDomain(it) }
+	}
+
+	fun updateTask(task: Task): Task {
+		val entity =
+			taskRepository.findById(task.id)
+				.orElseThrow { TaskNotFoundException(task.id) }
+
+		entity.status = task.status.code
+		entity.externalJobId = task.externalJobId
+		entity.retryCount = task.retryCount
+		entity.result = task.result
+		entity.errorCode = task.errorCode
+		entity.errorMessage = task.errorMessage
+		entity.updatedAt = task.updatedAt
+
+		val saved = taskRepository.save(entity)
+		return TaskMapper.toDomain(saved)
+	}
+
+	companion object {
+		private const val IDEMPOTENCY_EXPIRY_HOURS = 24L
+	}
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -37,6 +37,12 @@ mock-worker:
     candidate-name: ${MOCK_WORKER_CANDIDATE_NAME}
     email: ${MOCK_WORKER_EMAIL}
 
+task:
+  max-retry-count: 3
+  polling:
+    initial-interval-ms: 2000
+    max-interval-ms: 10000
+
 resilience4j:
   circuitbreaker:
     instances:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -21,3 +21,9 @@ mock-worker:
   auth:
     candidate-name: test-candidate
     email: test@example.com
+
+task:
+  max-retry-count: 3
+  polling:
+    initial-interval-ms: 100
+    max-interval-ms: 500


### PR DESCRIPTION
## Summary
- TaskService CRUD 구현 (생성, 단건/목록 조회, 상태 업데이트)
- 멱등성 키 기반 중복 요청 방지 (24시간 윈도우, 레이스 컨디션 처리)
- TaskOrchestrator 비동기 처리 (코루틴 기반 상태 전이 및 외부 API 호출)
- 외부 작업 상태 폴링 (지수 백오프 2s~10s)
- TaskRecoveryService 구현 (서버 재시작 시 미완료 작업 복구)
- application.yaml task 설정 추가

Closes #26