### PR TITLE
[feat] feat/003-04-rest-controller

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16")

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/controller/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/controller/GlobalExceptionHandler.kt
@@ -1,0 +1,74 @@
+package org.sampletask.foreign_api_sample.task.controller
+
+import org.sampletask.foreign_api_sample.task.controller.dto.ErrorResponse
+import org.sampletask.foreign_api_sample.task.exception.ApiKeyUnavailableException
+import org.sampletask.foreign_api_sample.task.exception.BusinessException
+import org.sampletask.foreign_api_sample.task.exception.IdempotencyKeyConflictException
+import org.sampletask.foreign_api_sample.task.exception.InvalidTaskStateException
+import org.sampletask.foreign_api_sample.task.exception.MockWorkerException
+import org.sampletask.foreign_api_sample.task.exception.SystemException
+import org.sampletask.foreign_api_sample.task.exception.TaskNotFoundException
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingRequestHeaderException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+	private val log = LoggerFactory.getLogger(javaClass)
+
+	@ExceptionHandler(BusinessException::class)
+	fun handleBusinessException(e: BusinessException): ResponseEntity<ErrorResponse> {
+		@Suppress("UNUSED_VARIABLE")
+		val exhaustive: Unit =
+			when (e) {
+				is TaskNotFoundException -> log.debug("Task not found: {}", e.taskId)
+				is IdempotencyKeyConflictException -> log.debug("Idempotency key conflict: {}", e.idempotencyKey)
+				is InvalidTaskStateException -> log.debug("Invalid task state: {} -> {}", e.currentStatus, e.attemptedStatus)
+			}
+		return ResponseEntity
+			.status(e.httpStatus)
+			.body(ErrorResponse(code = e.errorCode, message = e.message))
+	}
+
+	@ExceptionHandler(SystemException::class)
+	fun handleSystemException(e: SystemException): ResponseEntity<ErrorResponse> {
+		@Suppress("UNUSED_VARIABLE")
+		val exhaustive: Unit =
+			when (e) {
+				is MockWorkerException -> log.error("외부 서비스 오류: {}", e.message)
+				is ApiKeyUnavailableException -> log.error("API Key 사용 불가: {}", e.message)
+			}
+		return ResponseEntity
+			.status(e.httpStatus)
+			.body(ErrorResponse(code = e.errorCode, message = e.message))
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException::class)
+	fun handleValidation(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
+		val message =
+			e.bindingResult.fieldErrors.joinToString(", ") {
+				"${it.field}: ${it.defaultMessage}"
+			}
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body(ErrorResponse(code = "VALIDATION_ERROR", message = message))
+	}
+
+	@ExceptionHandler(MissingRequestHeaderException::class)
+	fun handleMissingHeader(e: MissingRequestHeaderException): ResponseEntity<ErrorResponse> {
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body(ErrorResponse(code = "MISSING_HEADER", message = e.message))
+	}
+
+	@ExceptionHandler(IllegalArgumentException::class)
+	fun handleIllegalArgument(e: IllegalArgumentException): ResponseEntity<ErrorResponse> {
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body(ErrorResponse(code = "BAD_REQUEST", message = e.message ?: "Bad request"))
+	}
+}

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/controller/TaskController.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/controller/TaskController.kt
@@ -1,0 +1,86 @@
+package org.sampletask.foreign_api_sample.task.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.sampletask.foreign_api_sample.task.controller.dto.CreateTaskRequest
+import org.sampletask.foreign_api_sample.task.controller.dto.TaskResponse
+import org.sampletask.foreign_api_sample.task.domain.TaskStatus
+import org.sampletask.foreign_api_sample.task.service.TaskOrchestrator
+import org.sampletask.foreign_api_sample.task.service.TaskService
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "Tasks", description = "이미지 처리 작업 API")
+@RestController
+@RequestMapping("/api/tasks")
+class TaskController(
+	private val taskService: TaskService,
+	private val taskOrchestrator: TaskOrchestrator,
+) {
+	@Operation(summary = "작업 생성", description = "이미지 처리 작업을 생성하고 비동기 처리를 시작합니다")
+	@ApiResponses(
+		ApiResponse(responseCode = "202", description = "작업 생성 완료 (비동기 처리 시작)"),
+		ApiResponse(responseCode = "400", description = "잘못된 요청"),
+		ApiResponse(responseCode = "409", description = "멱등성 키 충돌"),
+	)
+	@PostMapping
+	fun createTask(
+		@RequestHeader("X-Idempotency-Key") idempotencyKey: String,
+		@Valid @RequestBody request: CreateTaskRequest,
+	): ResponseEntity<TaskResponse> {
+		val task = taskService.createTask(idempotencyKey, request.imageUrl)
+
+		if (task.status == TaskStatus.PENDING) {
+			taskOrchestrator.submitAsync(task)
+		}
+
+		return ResponseEntity
+			.status(HttpStatus.ACCEPTED)
+			.body(TaskResponse.from(task))
+	}
+
+	@Operation(summary = "작업 조회", description = "작업 ID로 작업 상태와 결과를 조회합니다")
+	@ApiResponses(
+		ApiResponse(responseCode = "200", description = "조회 성공"),
+		ApiResponse(responseCode = "404", description = "작업을 찾을 수 없음"),
+	)
+	@GetMapping("/{taskId}")
+	fun getTask(@PathVariable taskId: Long): ResponseEntity<TaskResponse> {
+		val task = taskService.getTask(taskId)
+		return ResponseEntity.ok(TaskResponse.from(task))
+	}
+
+	@Operation(summary = "작업 목록 조회", description = "작업 목록을 페이지네이션으로 조회합니다")
+	@ApiResponse(responseCode = "200", description = "조회 성공")
+	@GetMapping
+	fun listTasks(
+		@RequestParam(required = false) status: String?,
+		@RequestParam(defaultValue = "0") page: Int,
+		@RequestParam(defaultValue = "20") size: Int,
+	): ResponseEntity<Page<TaskResponse>> {
+		val pageSize = size.coerceAtMost(MAX_PAGE_SIZE)
+		val pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Direction.DESC, "createdAt"))
+		val taskStatus = status?.let { TaskStatus.valueOf(it) }
+
+		val tasks = taskService.listTasks(taskStatus, pageable)
+		return ResponseEntity.ok(tasks.map { TaskResponse.from(it) })
+	}
+
+	companion object {
+		private const val MAX_PAGE_SIZE = 50
+	}
+}

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/controller/dto/CreateTaskRequest.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/controller/dto/CreateTaskRequest.kt
@@ -1,0 +1,11 @@
+package org.sampletask.foreign_api_sample.task.controller.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+
+@Schema(description = "작업 생성 요청")
+data class CreateTaskRequest(
+	@field:NotBlank(message = "imageUrl은 필수입니다")
+	@Schema(description = "처리할 이미지 URL", example = "https://example.com/image.png")
+	val imageUrl: String,
+)

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/controller/dto/ErrorResponse.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/controller/dto/ErrorResponse.kt
@@ -1,0 +1,14 @@
+package org.sampletask.foreign_api_sample.task.controller.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.Instant
+
+@Schema(description = "에러 응답")
+data class ErrorResponse(
+	@Schema(description = "에러 코드")
+	val code: String,
+	@Schema(description = "에러 메시지")
+	val message: String,
+	@Schema(description = "발생 시각")
+	val timestamp: Instant = Instant.now(),
+)

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/controller/dto/TaskResponse.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/controller/dto/TaskResponse.kt
@@ -1,0 +1,40 @@
+package org.sampletask.foreign_api_sample.task.controller.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.sampletask.foreign_api_sample.task.domain.Task
+import java.time.Instant
+
+@Schema(description = "작업 응답")
+data class TaskResponse(
+	@Schema(description = "작업 ID")
+	val id: Long,
+	@Schema(description = "작업 상태", example = "PENDING")
+	val status: String,
+	@Schema(description = "이미지 URL")
+	val imageUrl: String,
+	@Schema(description = "처리 결과", nullable = true)
+	val result: String?,
+	@Schema(description = "에러 코드", nullable = true)
+	val errorCode: String?,
+	@Schema(description = "에러 메시지", nullable = true)
+	val errorMessage: String?,
+	@Schema(description = "생성 시각")
+	val createdAt: Instant,
+	@Schema(description = "수정 시각")
+	val updatedAt: Instant,
+) {
+	companion object {
+		fun from(task: Task): TaskResponse {
+			return TaskResponse(
+				id = task.id,
+				status = task.status.name,
+				imageUrl = task.imageUrl,
+				result = task.result,
+				errorCode = task.errorCode,
+				errorMessage = task.errorMessage,
+				createdAt = task.createdAt,
+				updatedAt = task.updatedAt,
+			)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- POST /api/tasks 엔드포인트 (멱등성 키 헤더, 요청 검증, 202 응답)
- GET /api/tasks/{taskId} 엔드포인트 (단건 조회)
- GET /api/tasks 엔드포인트 (페이지네이션, 상태 필터, 최신순 정렬)
- GlobalExceptionHandler 구현 (sealed 예외별 HTTP 상태/에러 코드 매핑)
- 응답 DTO 정의 (CreateTaskRequest, TaskResponse, ErrorResponse)
- spring-boot-starter-validation 의존성 추가

Closes #27