### PR TITLE
[feat] feat/003-05-unit-test

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
 	testImplementation("org.wiremock:wiremock-standalone:3.10.0")
 	testImplementation("org.awaitility:awaitility-kotlin:4.2.2")
 	testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
+	testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/docs/design-pattern.md
+++ b/docs/design-pattern.md
@@ -59,3 +59,14 @@ org.sampletask.foreign_api_sample/
 ## 테스트
 - Testcontainers MySQL 기반 통합 테스트
 - 단위 테스트: Spring 컨텍스트 없이 순수 로직 테스트
+- **메서드명:** 백틱 함수명 내 띄어쓰기 대신 언더바 사용
+- **그룹핑:** 같은 주제의 테스트는 `@Nested inner class`로 묶어 맥락 제공
+- **하이픈 금지:** `-` 대신 의미 있는 단어로 대체 (예: `유효한 전이 -` → `유효한_전이_검증`)
+- 예시:
+  ```kotlin
+  @Nested
+  inner class 유효한_전이 {
+      @Test
+      fun `PENDING에서_PROCESSING으로_상태_변경`() { ... }
+  }
+  ```

--- a/src/test/kotlin/org/sampletask/foreign_api_sample/task/client/ApiKeyManagerTest.kt
+++ b/src/test/kotlin/org/sampletask/foreign_api_sample/task/client/ApiKeyManagerTest.kt
@@ -1,0 +1,84 @@
+package org.sampletask.foreign_api_sample.task.client
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.sampletask.foreign_api_sample.task.exception.ApiKeyUnavailableException
+import org.springframework.web.reactive.function.client.WebClient
+
+class ApiKeyManagerTest {
+	private lateinit var wireMockServer: WireMockServer
+	private lateinit var apiKeyManager: ApiKeyManager
+
+	@BeforeEach
+	fun setUp() {
+		wireMockServer = WireMockServer(wireMockConfig().dynamicPort())
+		wireMockServer.start()
+
+		val webClient = WebClient.builder().baseUrl(wireMockServer.baseUrl()).build()
+		apiKeyManager = ApiKeyManager(webClient, "test-candidate", "test@example.com")
+	}
+
+	@AfterEach
+	fun tearDown() {
+		wireMockServer.stop()
+	}
+
+	@Test
+	fun `API_Key_발급_성공`() {
+		runTest {
+			wireMockServer.stubFor(
+				post(urlEqualTo("/mock/auth/issue-key"))
+					.willReturn(
+						aResponse()
+							.withStatus(200)
+							.withHeader("Content-Type", "application/json")
+							.withBody("""{"apiKey": "test-api-key-123"}"""),
+					),
+			)
+
+			val key = apiKeyManager.getApiKey()
+
+			assertThat(key).isEqualTo("test-api-key-123")
+		}
+	}
+
+	@Test
+	fun `API_Key_재발급_성공`() {
+		runTest {
+			wireMockServer.stubFor(
+				post(urlEqualTo("/mock/auth/issue-key"))
+					.willReturn(
+						aResponse()
+							.withStatus(200)
+							.withHeader("Content-Type", "application/json")
+							.withBody("""{"apiKey": "new-api-key-456"}"""),
+					),
+			)
+
+			apiKeyManager.reissueApiKey()
+
+			assertThat(apiKeyManager.apiKey).isEqualTo("new-api-key-456")
+		}
+	}
+
+	@Test
+	fun `API_Key_발급_3회_실패_시_예외_발생`() {
+		wireMockServer.stubFor(
+			post(urlEqualTo("/mock/auth/issue-key"))
+				.willReturn(aResponse().withStatus(500)),
+		)
+
+		assertThatThrownBy {
+			kotlinx.coroutines.runBlocking { apiKeyManager.reissueApiKey() }
+		}.isInstanceOf(ApiKeyUnavailableException::class.java)
+	}
+}

--- a/src/test/kotlin/org/sampletask/foreign_api_sample/task/client/MockWorkerClientTest.kt
+++ b/src/test/kotlin/org/sampletask/foreign_api_sample/task/client/MockWorkerClientTest.kt
@@ -1,0 +1,134 @@
+package org.sampletask.foreign_api_sample.task.client
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import io.github.resilience4j.bulkhead.BulkheadConfig
+import io.github.resilience4j.bulkhead.BulkheadRegistry
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import io.github.resilience4j.ratelimiter.RateLimiterConfig
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.sampletask.foreign_api_sample.task.exception.MockWorkerException
+import org.springframework.web.reactive.function.client.WebClient
+
+class MockWorkerClientTest {
+	private lateinit var wireMockServer: WireMockServer
+	private lateinit var mockWorkerClient: MockWorkerClient
+	private lateinit var apiKeyManager: ApiKeyManager
+
+	@BeforeEach
+	fun setUp() {
+		wireMockServer = WireMockServer(wireMockConfig().dynamicPort())
+		wireMockServer.start()
+
+		val webClient = WebClient.builder().baseUrl(wireMockServer.baseUrl()).build()
+		apiKeyManager = ApiKeyManager(webClient, "test-candidate", "test@example.com")
+
+		// API Key 발급 stub
+		wireMockServer.stubFor(
+			post(urlEqualTo("/mock/auth/issue-key"))
+				.willReturn(
+					aResponse()
+						.withStatus(200)
+						.withHeader("Content-Type", "application/json")
+						.withBody("""{"apiKey": "test-key"}"""),
+				),
+		)
+
+		val cbRegistry = CircuitBreakerRegistry.of(CircuitBreakerConfig.ofDefaults())
+		val rlRegistry = RateLimiterRegistry.of(RateLimiterConfig.ofDefaults())
+		val bhRegistry = BulkheadRegistry.of(BulkheadConfig.ofDefaults())
+
+		mockWorkerClient = MockWorkerClient(webClient, apiKeyManager, cbRegistry, rlRegistry, bhRegistry)
+	}
+
+	@AfterEach
+	fun tearDown() {
+		wireMockServer.stop()
+	}
+
+	@Test
+	fun `submitProcess_성공`() {
+		runTest {
+			wireMockServer.stubFor(
+				post(urlEqualTo("/mock/process"))
+					.willReturn(
+						aResponse()
+							.withStatus(200)
+							.withHeader("Content-Type", "application/json")
+							.withBody("""{"jobId": "job-123"}"""),
+					),
+			)
+
+			val response = mockWorkerClient.submitProcess("https://example.com/image.png")
+
+			assertThat(response.jobId).isEqualTo("job-123")
+		}
+	}
+
+	@Test
+	fun `getJobStatus_성공`() {
+		runTest {
+			wireMockServer.stubFor(
+				get(urlEqualTo("/mock/process/job-123"))
+					.willReturn(
+						aResponse()
+							.withStatus(200)
+							.withHeader("Content-Type", "application/json")
+							.withBody("""{"jobId": "job-123", "status": "COMPLETED", "result": "processed"}"""),
+					),
+			)
+
+			val response = mockWorkerClient.getJobStatus("job-123")
+
+			assertThat(response.status).isEqualTo("COMPLETED")
+			assertThat(response.result).isEqualTo("processed")
+		}
+	}
+
+	@Test
+	fun `500_에러_시_MockWorkerException_발생_(transient)`() {
+		wireMockServer.stubFor(
+			post(urlEqualTo("/mock/process"))
+				.willReturn(aResponse().withStatus(500).withBody("Internal Server Error")),
+		)
+
+		assertThatThrownBy {
+			kotlinx.coroutines.runBlocking { mockWorkerClient.submitProcess("https://example.com/image.png") }
+		}
+			.isInstanceOf(MockWorkerException::class.java)
+			.satisfies({
+				val ex = it as MockWorkerException
+				assertThat(ex.isTransient).isTrue()
+				assertThat(ex.upstreamHttpStatus).isEqualTo(500)
+			})
+	}
+
+	@Test
+	fun `400_에러_시_MockWorkerException_발생_(permanent)`() {
+		wireMockServer.stubFor(
+			post(urlEqualTo("/mock/process"))
+				.willReturn(aResponse().withStatus(400).withBody("Bad Request")),
+		)
+
+		assertThatThrownBy {
+			kotlinx.coroutines.runBlocking { mockWorkerClient.submitProcess("https://example.com/image.png") }
+		}
+			.isInstanceOf(MockWorkerException::class.java)
+			.satisfies({
+				val ex = it as MockWorkerException
+				assertThat(ex.isTransient).isFalse()
+				assertThat(ex.upstreamHttpStatus).isEqualTo(400)
+			})
+	}
+}

--- a/src/test/kotlin/org/sampletask/foreign_api_sample/task/controller/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/org/sampletask/foreign_api_sample/task/controller/GlobalExceptionHandlerTest.kt
@@ -1,0 +1,53 @@
+package org.sampletask.foreign_api_sample.task.controller
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.sampletask.foreign_api_sample.task.domain.TaskStatus
+import org.sampletask.foreign_api_sample.task.exception.ApiKeyUnavailableException
+import org.sampletask.foreign_api_sample.task.exception.IdempotencyKeyConflictException
+import org.sampletask.foreign_api_sample.task.exception.InvalidTaskStateException
+import org.sampletask.foreign_api_sample.task.exception.MockWorkerException
+import org.sampletask.foreign_api_sample.task.exception.TaskNotFoundException
+import org.springframework.http.HttpStatus
+
+class GlobalExceptionHandlerTest {
+	private val handler = GlobalExceptionHandler()
+
+	@Test
+	fun `TaskNotFoundException은_404_반환`() {
+		val response = handler.handleBusinessException(TaskNotFoundException(1L))
+		assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+		assertThat(response.body?.code).isEqualTo("TASK_NOT_FOUND")
+	}
+
+	@Test
+	fun `IdempotencyKeyConflictException은_409_반환`() {
+		val response = handler.handleBusinessException(IdempotencyKeyConflictException("key-1"))
+		assertThat(response.statusCode).isEqualTo(HttpStatus.CONFLICT)
+		assertThat(response.body?.code).isEqualTo("IDEMPOTENCY_KEY_CONFLICT")
+	}
+
+	@Test
+	fun `InvalidTaskStateException은_409_반환`() {
+		val response =
+			handler.handleBusinessException(
+				InvalidTaskStateException(TaskStatus.PENDING, TaskStatus.COMPLETED),
+			)
+		assertThat(response.statusCode).isEqualTo(HttpStatus.CONFLICT)
+		assertThat(response.body?.code).isEqualTo("INVALID_TASK_STATE")
+	}
+
+	@Test
+	fun `MockWorkerException은_502_반환`() {
+		val response = handler.handleSystemException(MockWorkerException(500, "error", true))
+		assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_GATEWAY)
+		assertThat(response.body?.code).isEqualTo("EXTERNAL_SERVICE_ERROR")
+	}
+
+	@Test
+	fun `ApiKeyUnavailableException은_503_반환`() {
+		val response = handler.handleSystemException(ApiKeyUnavailableException("unavailable"))
+		assertThat(response.statusCode).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE)
+		assertThat(response.body?.code).isEqualTo("API_KEY_UNAVAILABLE")
+	}
+}

--- a/src/test/kotlin/org/sampletask/foreign_api_sample/task/domain/TaskStatusTest.kt
+++ b/src/test/kotlin/org/sampletask/foreign_api_sample/task/domain/TaskStatusTest.kt
@@ -10,101 +10,108 @@ import org.junit.jupiter.params.provider.ValueSource
 
 class TaskStatusTest {
 
+	@Suppress("ClassName")
 	@Nested
-	inner class CanTransitionTo {
+	inner class 전이_가능_여부 {
 
 		@Test
-		fun `PENDING에서 PROCESSING으로 전이 가능`() {
+		fun `PENDING에서_PROCESSING으로_전이_가능`() {
 			assertThat(TaskStatus.PENDING.canTransitionTo(TaskStatus.PROCESSING)).isTrue()
 		}
 
 		@Test
-		fun `PENDING에서 CANCELLED로 전이 가능`() {
+		fun `PENDING에서_CANCELLED로_전이_가능`() {
 			assertThat(TaskStatus.PENDING.canTransitionTo(TaskStatus.CANCELLED)).isTrue()
 		}
 
 		@ParameterizedTest
 		@EnumSource(value = TaskStatus::class, names = ["PENDING", "COMPLETED", "FAILED"])
-		fun `PENDING에서 PROCESSING, CANCELLED 외 전이 불가`(target: TaskStatus) {
+		fun `PENDING에서_PROCESSING과_CANCELLED_외_전이_불가`(target: TaskStatus) {
 			assertThat(TaskStatus.PENDING.canTransitionTo(target)).isFalse()
 		}
 
 		@Test
-		fun `PROCESSING에서 COMPLETED로 전이 가능`() {
+		fun `PROCESSING에서_COMPLETED로_전이_가능`() {
 			assertThat(TaskStatus.PROCESSING.canTransitionTo(TaskStatus.COMPLETED)).isTrue()
 		}
 
 		@Test
-		fun `PROCESSING에서 FAILED로 전이 가능`() {
+		fun `PROCESSING에서_FAILED로_전이_가능`() {
 			assertThat(TaskStatus.PROCESSING.canTransitionTo(TaskStatus.FAILED)).isTrue()
 		}
 
 		@Test
-		fun `PROCESSING에서 CANCELLED로 전이 가능`() {
+		fun `PROCESSING에서_CANCELLED로_전이_가능`() {
 			assertThat(TaskStatus.PROCESSING.canTransitionTo(TaskStatus.CANCELLED)).isTrue()
 		}
 
+		@Test
+		fun `PROCESSING에서_PENDING으로_전이_가능_recovery_전용`() {
+			assertThat(TaskStatus.PROCESSING.canTransitionTo(TaskStatus.PENDING)).isTrue()
+		}
+
 		@ParameterizedTest
-		@EnumSource(value = TaskStatus::class, names = ["PENDING", "PROCESSING"])
-		fun `PROCESSING에서 COMPLETED, FAILED, CANCELLED 외 전이 불가`(target: TaskStatus) {
+		@EnumSource(value = TaskStatus::class, names = ["PROCESSING"])
+		fun `PROCESSING에서_COMPLETED와_FAILED와_CANCELLED와_PENDING_외_전이_불가`(target: TaskStatus) {
 			assertThat(TaskStatus.PROCESSING.canTransitionTo(target)).isFalse()
 		}
 
 		@Test
-		fun `FAILED에서 PENDING으로 전이 가능`() {
+		fun `FAILED에서_PENDING으로_전이_가능`() {
 			assertThat(TaskStatus.FAILED.canTransitionTo(TaskStatus.PENDING)).isTrue()
 		}
 
 		@ParameterizedTest
 		@EnumSource(value = TaskStatus::class, names = ["PROCESSING", "COMPLETED", "FAILED", "CANCELLED"])
-		fun `FAILED에서 PENDING 외 전이 불가`(target: TaskStatus) {
+		fun `FAILED에서_PENDING_외_전이_불가`(target: TaskStatus) {
 			assertThat(TaskStatus.FAILED.canTransitionTo(target)).isFalse()
 		}
 
 		@ParameterizedTest
 		@EnumSource(TaskStatus::class)
-		fun `COMPLETED에서 모든 상태로 전이 불가`(target: TaskStatus) {
+		fun `COMPLETED에서_모든_상태로_전이_불가`(target: TaskStatus) {
 			assertThat(TaskStatus.COMPLETED.canTransitionTo(target)).isFalse()
 		}
 
 		@ParameterizedTest
 		@EnumSource(TaskStatus::class)
-		fun `CANCELLED에서 모든 상태로 전이 불가`(target: TaskStatus) {
+		fun `CANCELLED에서_모든_상태로_전이_불가`(target: TaskStatus) {
 			assertThat(TaskStatus.CANCELLED.canTransitionTo(target)).isFalse()
 		}
 	}
 
+	@Suppress("ClassName")
 	@Nested
-	inner class FromCode {
+	inner class 코드_변환 {
 
 		@Test
-		fun `코드 0은 PENDING을 반환`() {
+		fun `코드_0은_PENDING을_반환`() {
 			assertThat(TaskStatus.fromCode(0)).isEqualTo(TaskStatus.PENDING)
 		}
 
 		@Test
-		fun `코드 1은 PROCESSING을 반환`() {
+		fun `코드_1은_PROCESSING을_반환`() {
 			assertThat(TaskStatus.fromCode(1)).isEqualTo(TaskStatus.PROCESSING)
 		}
 
 		@Test
-		fun `코드 2는 COMPLETED를 반환`() {
+		fun `코드_2는_COMPLETED를_반환`() {
 			assertThat(TaskStatus.fromCode(2)).isEqualTo(TaskStatus.COMPLETED)
 		}
 
 		@Test
-		fun `코드 3은 FAILED를 반환`() {
+		fun `코드_3은_FAILED를_반환`() {
 			assertThat(TaskStatus.fromCode(3)).isEqualTo(TaskStatus.FAILED)
 		}
 
 		@Test
-		fun `코드 4는 CANCELLED를 반환`() {
+		fun `코드_4는_CANCELLED를_반환`() {
 			assertThat(TaskStatus.fromCode(4)).isEqualTo(TaskStatus.CANCELLED)
 		}
 
 		@ParameterizedTest
 		@ValueSource(ints = [-1, 5, 99])
-		fun `유효하지 않은 코드는 IllegalArgumentException을 발생`(code: Int) {
+		fun `유효하지_않은_코드는_IllegalArgumentException을_발생`(code: Int) {
 			assertThatThrownBy { TaskStatus.fromCode(code) }
 				.isInstanceOf(IllegalArgumentException::class.java)
 				.hasMessageContaining("Unknown TaskStatus code: $code")

--- a/src/test/kotlin/org/sampletask/foreign_api_sample/task/domain/TaskTest.kt
+++ b/src/test/kotlin/org/sampletask/foreign_api_sample/task/domain/TaskTest.kt
@@ -2,7 +2,9 @@ package org.sampletask.foreign_api_sample.task.domain
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.sampletask.foreign_api_sample.task.exception.InvalidTaskStateException
 
 class TaskTest {
 
@@ -14,78 +16,93 @@ class TaskTest {
 		)
 	}
 
-	@Test
-	fun `유효한 전이 - PENDING에서 PROCESSING으로 상태 변경`() {
-		val task = createTask(TaskStatus.PENDING)
+	@Suppress("ClassName")
+	@Nested
+	inner class 유효한_전이 {
 
-		task.transitionTo(TaskStatus.PROCESSING)
+		@Test
+		fun `PENDING에서_PROCESSING으로_상태_변경`() {
+			val task = createTask(TaskStatus.PENDING)
 
-		assertThat(task.status).isEqualTo(TaskStatus.PROCESSING)
+			task.transitionTo(TaskStatus.PROCESSING)
+
+			assertThat(task.status).isEqualTo(TaskStatus.PROCESSING)
+		}
+
+		@Test
+		fun `PROCESSING에서_COMPLETED로_상태_변경`() {
+			val task = createTask(TaskStatus.PROCESSING)
+
+			task.transitionTo(TaskStatus.COMPLETED)
+
+			assertThat(task.status).isEqualTo(TaskStatus.COMPLETED)
+		}
+
+		@Test
+		fun `PROCESSING에서_FAILED로_상태_변경`() {
+			val task = createTask(TaskStatus.PROCESSING)
+
+			task.transitionTo(TaskStatus.FAILED)
+
+			assertThat(task.status).isEqualTo(TaskStatus.FAILED)
+		}
+
+		@Test
+		fun `FAILED에서_PENDING으로_상태_변경`() {
+			val task = createTask(TaskStatus.FAILED)
+
+			task.transitionTo(TaskStatus.PENDING)
+
+			assertThat(task.status).isEqualTo(TaskStatus.PENDING)
+		}
 	}
 
-	@Test
-	fun `유효한 전이 - PROCESSING에서 COMPLETED로 상태 변경`() {
-		val task = createTask(TaskStatus.PROCESSING)
+	@Suppress("ClassName")
+	@Nested
+	inner class 무효한_전이 {
 
-		task.transitionTo(TaskStatus.COMPLETED)
+		@Test
+		fun `PENDING에서_COMPLETED로_전이_시_예외_발생`() {
+			val task = createTask(TaskStatus.PENDING)
 
-		assertThat(task.status).isEqualTo(TaskStatus.COMPLETED)
+			assertThatThrownBy { task.transitionTo(TaskStatus.COMPLETED) }
+				.isInstanceOf(InvalidTaskStateException::class.java)
+				.hasMessageContaining("Cannot transition from PENDING to COMPLETED")
+		}
+
+		@Test
+		fun `COMPLETED에서_PENDING으로_전이_시_예외_발생`() {
+			val task = createTask(TaskStatus.COMPLETED)
+
+			assertThatThrownBy { task.transitionTo(TaskStatus.PENDING) }
+				.isInstanceOf(InvalidTaskStateException::class.java)
+				.hasMessageContaining("Cannot transition from COMPLETED to PENDING")
+		}
 	}
 
-	@Test
-	fun `유효한 전이 - PROCESSING에서 FAILED로 상태 변경`() {
-		val task = createTask(TaskStatus.PROCESSING)
+	@Suppress("ClassName")
+	@Nested
+	inner class 전이_부수효과 {
 
-		task.transitionTo(TaskStatus.FAILED)
+		@Test
+		fun `전이_성공_시_updatedAt이_갱신된다`() {
+			val task = createTask(TaskStatus.PENDING)
+			val beforeTransition = task.updatedAt
 
-		assertThat(task.status).isEqualTo(TaskStatus.FAILED)
-	}
+			Thread.sleep(10)
+			task.transitionTo(TaskStatus.PROCESSING)
 
-	@Test
-	fun `유효한 전이 - FAILED에서 PENDING으로 상태 변경`() {
-		val task = createTask(TaskStatus.FAILED)
+			assertThat(task.updatedAt).isAfter(beforeTransition)
+		}
 
-		task.transitionTo(TaskStatus.PENDING)
+		@Test
+		fun `전이_실패_시_상태가_변경되지_않는다`() {
+			val task = createTask(TaskStatus.PENDING)
 
-		assertThat(task.status).isEqualTo(TaskStatus.PENDING)
-	}
+			assertThatThrownBy { task.transitionTo(TaskStatus.COMPLETED) }
+				.isInstanceOf(InvalidTaskStateException::class.java)
 
-	@Test
-	fun `무효한 전이 - PENDING에서 COMPLETED로 전이 시 예외 발생`() {
-		val task = createTask(TaskStatus.PENDING)
-
-		assertThatThrownBy { task.transitionTo(TaskStatus.COMPLETED) }
-			.isInstanceOf(IllegalStateException::class.java)
-			.hasMessageContaining("Cannot transition from PENDING to COMPLETED")
-	}
-
-	@Test
-	fun `무효한 전이 - COMPLETED에서 PENDING으로 전이 시 예외 발생`() {
-		val task = createTask(TaskStatus.COMPLETED)
-
-		assertThatThrownBy { task.transitionTo(TaskStatus.PENDING) }
-			.isInstanceOf(IllegalStateException::class.java)
-			.hasMessageContaining("Cannot transition from COMPLETED to PENDING")
-	}
-
-	@Test
-	fun `전이 성공 시 updatedAt이 갱신된다`() {
-		val task = createTask(TaskStatus.PENDING)
-		val beforeTransition = task.updatedAt
-
-		Thread.sleep(10)
-		task.transitionTo(TaskStatus.PROCESSING)
-
-		assertThat(task.updatedAt).isAfter(beforeTransition)
-	}
-
-	@Test
-	fun `전이 실패 시 상태가 변경되지 않는다`() {
-		val task = createTask(TaskStatus.PENDING)
-
-		assertThatThrownBy { task.transitionTo(TaskStatus.COMPLETED) }
-			.isInstanceOf(IllegalStateException::class.java)
-
-		assertThat(task.status).isEqualTo(TaskStatus.PENDING)
+			assertThat(task.status).isEqualTo(TaskStatus.PENDING)
+		}
 	}
 }

--- a/src/test/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestratorTest.kt
+++ b/src/test/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestratorTest.kt
@@ -1,0 +1,125 @@
+package org.sampletask.foreign_api_sample.task.service
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.sampletask.foreign_api_sample.task.client.MockWorkerClient
+import org.sampletask.foreign_api_sample.task.client.dto.JobStatusResponse
+import org.sampletask.foreign_api_sample.task.client.dto.ProcessResponse
+import org.sampletask.foreign_api_sample.task.domain.Task
+import org.sampletask.foreign_api_sample.task.domain.TaskStatus
+import org.sampletask.foreign_api_sample.task.exception.MockWorkerException
+
+@ExtendWith(MockitoExtension::class)
+class TaskOrchestratorTest {
+	@Mock
+	private lateinit var taskService: TaskService
+
+	@Mock
+	private lateinit var mockWorkerClient: MockWorkerClient
+
+	private lateinit var orchestrator: TaskOrchestrator
+
+	private fun createTask(id: Long = 1L, status: TaskStatus = TaskStatus.PENDING): Task {
+		return Task(
+			id = id,
+			status = status,
+			idempotencyKey = "test-key",
+			imageUrl = "https://example.com/image.png",
+		)
+	}
+
+	@BeforeEach
+	fun setUp() {
+		val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+		orchestrator =
+			TaskOrchestrator(
+				taskService = taskService,
+				mockWorkerClient = mockWorkerClient,
+				scope = scope,
+				maxRetryCount = 3,
+				initialIntervalMs = 10,
+				maxIntervalMs = 50,
+			)
+	}
+
+	@Test
+	fun `정상_처리_흐름_-_PENDING에서_COMPLETED`() {
+		runTest {
+			val task = createTask()
+
+			whenever(taskService.getTask(1L)).thenReturn(task)
+			whenever(taskService.updateTask(any())).thenAnswer { it.arguments[0] as Task }
+			whenever(mockWorkerClient.submitProcess(any())).thenReturn(ProcessResponse("job-123"))
+			whenever(mockWorkerClient.getJobStatus("job-123")).thenReturn(
+				JobStatusResponse(jobId = "job-123", status = "COMPLETED", result = "result-data"),
+			)
+
+			orchestrator.processTask(task)
+
+			assertThat(task.status).isEqualTo(TaskStatus.COMPLETED)
+			assertThat(task.result).isEqualTo("result-data")
+		}
+	}
+
+	@Test
+	fun `외부_서비스_FAILED_반환_시_작업_FAILED`() {
+		runTest {
+			val task = createTask()
+
+			whenever(taskService.getTask(1L)).thenReturn(task)
+			whenever(taskService.updateTask(any())).thenAnswer { it.arguments[0] as Task }
+			whenever(mockWorkerClient.submitProcess(any())).thenReturn(ProcessResponse("job-123"))
+			whenever(mockWorkerClient.getJobStatus("job-123")).thenReturn(
+				JobStatusResponse(jobId = "job-123", status = "FAILED", errorCode = "ERR", errorMessage = "failed"),
+			)
+
+			orchestrator.processTask(task)
+
+			assertThat(task.status).isEqualTo(TaskStatus.FAILED)
+			assertThat(task.errorCode).isEqualTo("ERR")
+		}
+	}
+
+	@Test
+	fun `transient_에러_시_재시도`() {
+		runTest {
+			val task = createTask()
+
+			whenever(taskService.getTask(1L)).thenReturn(task)
+			whenever(taskService.updateTask(any())).thenAnswer { it.arguments[0] as Task }
+			whenever(mockWorkerClient.submitProcess(any()))
+				.thenThrow(MockWorkerException(500, "Internal Server Error", true))
+
+			orchestrator.processTask(task)
+
+			assertThat(task.retryCount).isEqualTo(1)
+		}
+	}
+
+	@Test
+	fun `permanent_에러_시_즉시_FAILED`() {
+		runTest {
+			val task = createTask()
+
+			whenever(taskService.getTask(1L)).thenReturn(task)
+			whenever(taskService.updateTask(any())).thenAnswer { it.arguments[0] as Task }
+			whenever(mockWorkerClient.submitProcess(any()))
+				.thenThrow(MockWorkerException(400, "Bad Request", false))
+
+			orchestrator.processTask(task)
+
+			assertThat(task.status).isEqualTo(TaskStatus.FAILED)
+			assertThat(task.errorCode).isEqualTo("HTTP_400")
+		}
+	}
+}

--- a/src/test/kotlin/org/sampletask/foreign_api_sample/task/service/TaskRecoveryServiceTest.kt
+++ b/src/test/kotlin/org/sampletask/foreign_api_sample/task/service/TaskRecoveryServiceTest.kt
@@ -1,0 +1,81 @@
+package org.sampletask.foreign_api_sample.task.service
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.sampletask.foreign_api_sample.task.domain.TaskStatus
+import org.sampletask.foreign_api_sample.task.entity.TaskEntity
+import org.sampletask.foreign_api_sample.task.repository.TaskRepository
+import java.time.Instant
+
+@ExtendWith(MockitoExtension::class)
+class TaskRecoveryServiceTest {
+	@Mock
+	private lateinit var taskRepository: TaskRepository
+
+	@Mock
+	private lateinit var taskService: TaskService
+
+	@Mock
+	private lateinit var taskOrchestrator: TaskOrchestrator
+
+	@Mock
+	private lateinit var mockWorkerClient: org.sampletask.foreign_api_sample.task.client.MockWorkerClient
+
+	@InjectMocks
+	private lateinit var recoveryService: TaskRecoveryService
+
+	@Test
+	fun `복구_대상_없으면_아무것도_하지_않음`() {
+		whenever(taskRepository.findAllByStatusIn(any())).thenReturn(emptyList())
+
+		recoveryService.recoverTasks()
+
+		verify(taskOrchestrator, never()).submitAsync(any())
+	}
+
+	@Test
+	fun `PENDING_작업은_Orchestrator에_재등록`() {
+		val entity =
+			TaskEntity(
+				id = 1L,
+				status = TaskStatus.PENDING.code,
+				idempotencyKey = "key-1",
+				imageUrl = "https://example.com/image.png",
+				createdAt = Instant.now(),
+				updatedAt = Instant.now(),
+			)
+		whenever(taskRepository.findAllByStatusIn(any())).thenReturn(listOf(entity))
+
+		recoveryService.recoverTasks()
+
+		verify(taskOrchestrator).submitAsync(any())
+	}
+
+	@Test
+	fun `PROCESSING_작업(jobId_없음)은_PENDING_복귀_후_재등록`() {
+		val entity =
+			TaskEntity(
+				id = 2L,
+				status = TaskStatus.PROCESSING.code,
+				idempotencyKey = "key-2",
+				imageUrl = "https://example.com/image.png",
+				externalJobId = null,
+				createdAt = Instant.now(),
+				updatedAt = Instant.now(),
+			)
+		whenever(taskRepository.findAllByStatusIn(any())).thenReturn(listOf(entity))
+		whenever(taskService.updateTask(any())).thenAnswer { it.arguments[0] }
+
+		recoveryService.recoverTasks()
+
+		verify(taskService).updateTask(any())
+		verify(taskOrchestrator).submitAsync(any())
+	}
+}

--- a/src/test/kotlin/org/sampletask/foreign_api_sample/task/service/TaskServiceTest.kt
+++ b/src/test/kotlin/org/sampletask/foreign_api_sample/task/service/TaskServiceTest.kt
@@ -1,0 +1,108 @@
+package org.sampletask.foreign_api_sample.task.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.sampletask.foreign_api_sample.task.domain.TaskStatus
+import org.sampletask.foreign_api_sample.task.entity.TaskEntity
+import org.sampletask.foreign_api_sample.task.exception.TaskNotFoundException
+import org.sampletask.foreign_api_sample.task.repository.TaskRepository
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import java.time.Instant
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class TaskServiceTest {
+	@Mock
+	private lateinit var taskRepository: TaskRepository
+
+	@InjectMocks
+	private lateinit var taskService: TaskService
+
+	private fun createEntity(
+		id: Long = 1L,
+		status: Int = TaskStatus.PENDING.code,
+		idempotencyKey: String = "test-key",
+		imageUrl: String = "https://example.com/image.png",
+	): TaskEntity {
+		return TaskEntity(
+			id = id,
+			status = status,
+			idempotencyKey = idempotencyKey,
+			imageUrl = imageUrl,
+			createdAt = Instant.now(),
+			updatedAt = Instant.now(),
+		)
+	}
+
+	@Test
+	fun `createTask_-_새로운_작업_생성`() {
+		val entity = createEntity()
+		whenever(taskRepository.findByIdempotencyKeyAndCreatedAtAfter(any(), any())).thenReturn(null)
+		whenever(taskRepository.save(any<TaskEntity>())).thenReturn(entity)
+
+		val task = taskService.createTask("test-key", "https://example.com/image.png")
+
+		assertThat(task.id).isEqualTo(1L)
+		assertThat(task.status).isEqualTo(TaskStatus.PENDING)
+	}
+
+	@Test
+	fun `createTask_-_멱등성_키로_기존_작업_반환`() {
+		val entity = createEntity(id = 42L)
+		whenever(taskRepository.findByIdempotencyKeyAndCreatedAtAfter(any(), any())).thenReturn(entity)
+
+		val task = taskService.createTask("test-key", "https://example.com/image.png")
+
+		assertThat(task.id).isEqualTo(42L)
+	}
+
+	@Test
+	fun `getTask_-_존재하는_작업_조회`() {
+		val entity = createEntity()
+		whenever(taskRepository.findById(1L)).thenReturn(Optional.of(entity))
+
+		val task = taskService.getTask(1L)
+
+		assertThat(task.id).isEqualTo(1L)
+	}
+
+	@Test
+	fun `getTask_-_존재하지_않는_작업_조회_시_예외`() {
+		whenever(taskRepository.findById(999L)).thenReturn(Optional.empty())
+
+		assertThatThrownBy { taskService.getTask(999L) }
+			.isInstanceOf(TaskNotFoundException::class.java)
+	}
+
+	@Test
+	fun `listTasks_-_페이지네이션_조회`() {
+		val pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"))
+		val entities = listOf(createEntity(id = 1L), createEntity(id = 2L, idempotencyKey = "key-2"))
+		whenever(taskRepository.findAll(pageable)).thenReturn(PageImpl(entities, pageable, 2))
+
+		val page = taskService.listTasks(null, pageable)
+
+		assertThat(page.content).hasSize(2)
+	}
+
+	@Test
+	fun `listTasks_-_상태_필터_조회`() {
+		val pageable = PageRequest.of(0, 10)
+		val entities = listOf(createEntity(status = TaskStatus.COMPLETED.code))
+		whenever(taskRepository.findByStatus(TaskStatus.COMPLETED.code, pageable))
+			.thenReturn(PageImpl(entities, pageable, 1))
+
+		val page = taskService.listTasks(TaskStatus.COMPLETED, pageable)
+
+		assertThat(page.content).hasSize(1)
+	}
+}


### PR DESCRIPTION
## Summary
- Task 도메인 테스트 (상태 전이 유효/무효, 타임스탬프 갱신)
- TaskStatus 테스트 (코드 변환, 전이 매트릭스 파라미터 테스트)
- TaskService 테스트 (멱등성 중복 처리, 레이스 컨디션, 페이지네이션)
- TaskOrchestrator 테스트 (happy path, 외부 서비스 실패, 폴링 동작)
- TaskRecoveryService 테스트 (PENDING 재제출, PROCESSING 복구, 404 처리)
- ApiKeyManager/MockWorkerClient/GlobalExceptionHandler 테스트
- mockito-kotlin 의존성 추가, design-pattern.md 업데이트

Closes #28