### PR TITLE
[feat] feat/004-01-http-status-detailed-handling

### DIFF
--- a/src/main/kotlin/org/sampletask/foreign_api_sample/common/ErrorCode.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/common/ErrorCode.kt
@@ -5,6 +5,7 @@ enum class ErrorCode(val code: String, val messageTemplate: String) {
 	IDEMPOTENCY_KEY_CONFLICT("IDEMPOTENCY_KEY_CONFLICT", "Idempotency key conflict: %s"),
 	INVALID_TASK_STATE("INVALID_TASK_STATE", "Cannot transition from %s to %s"),
 	EXTERNAL_SERVICE_ERROR("EXTERNAL_SERVICE_ERROR", "Mock Worker error: HTTP %s%s"),
+	EXTERNAL_HTTP_ERROR("EXTERNAL_HTTP_ERROR", "External service HTTP error: %s"),
 	API_KEY_UNAVAILABLE("API_KEY_UNAVAILABLE", "API Key unavailable: %s"),
 	VALIDATION_ERROR("VALIDATION_ERROR", "%s"),
 	MISSING_HEADER("MISSING_HEADER", "%s"),

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/client/MockWorkerClient.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/client/MockWorkerClient.kt
@@ -9,6 +9,7 @@ import io.github.resilience4j.ratelimiter.RateLimiterRegistry
 import org.sampletask.foreign_api_sample.task.client.request.ProcessRequest
 import org.sampletask.foreign_api_sample.task.client.response.JobStatusResponse
 import org.sampletask.foreign_api_sample.task.client.response.ProcessResponse
+import org.sampletask.foreign_api_sample.task.domain.RecoveryAction
 import org.sampletask.foreign_api_sample.task.exception.MockWorkerException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatusCode
@@ -87,11 +88,15 @@ class MockWorkerClient(
 
 	private fun toMockWorkerException(e: WebClientResponseException): MockWorkerException {
 		val statusCode = e.statusCode.value()
-		val isTransient = statusCode in listOf(429, 500, 502, 503, 504)
+		val recoveryAction = when (statusCode) {
+			404 -> RecoveryAction.REVERT_TO_PENDING
+			429, 500, 502, 503, 504 -> RecoveryAction.RETRY
+			else -> RecoveryAction.FAIL
+		}
 		return MockWorkerException(
 			upstreamHttpStatus = statusCode,
 			errorBody = e.responseBodyAsString,
-			isTransient = isTransient,
+			recoveryAction = recoveryAction,
 		)
 	}
 }

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/domain/RecoveryAction.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/domain/RecoveryAction.kt
@@ -1,0 +1,7 @@
+package org.sampletask.foreign_api_sample.task.domain
+
+enum class RecoveryAction {
+	RETRY,
+	FAIL,
+	REVERT_TO_PENDING,
+}

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/exception/MockWorkerException.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/exception/MockWorkerException.kt
@@ -2,12 +2,13 @@ package org.sampletask.foreign_api_sample.task.exception
 
 import org.sampletask.foreign_api_sample.common.ErrorCode
 import org.sampletask.foreign_api_sample.common.exception.SystemException
+import org.sampletask.foreign_api_sample.task.domain.RecoveryAction
 import org.springframework.http.HttpStatus
 
 class MockWorkerException(
 	val upstreamHttpStatus: Int,
 	val errorBody: String?,
-	val isTransient: Boolean,
+	val recoveryAction: RecoveryAction,
 ) : SystemException(
 	httpStatus = HttpStatus.BAD_GATEWAY,
 	errorCode = ErrorCode.EXTERNAL_SERVICE_ERROR,

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestrator.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestrator.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.sampletask.foreign_api_sample.common.ErrorCode
 import org.sampletask.foreign_api_sample.task.client.MockWorkerClient
+import org.sampletask.foreign_api_sample.task.domain.RecoveryAction
 import org.sampletask.foreign_api_sample.task.domain.Task
 import org.sampletask.foreign_api_sample.task.domain.TaskStatus
 import org.sampletask.foreign_api_sample.task.exception.MockWorkerException
@@ -83,15 +84,6 @@ class TaskOrchestrator(
 					}
 				}
 			} catch (e: MockWorkerException) {
-				if (e.upstreamHttpStatus == 404) {
-					log.warn("작업 {} 의 외부 Job {} 이 404 반환 - PENDING 복귀", taskId, jobId)
-					val current = taskService.getTask(taskId)
-					current.externalJobId = null
-					current.transitionTo(TaskStatus.PENDING)
-					val updated = taskService.updateTask(current)
-					submitAsync(updated)
-					return
-				}
 				handleError(taskId, e)
 				return
 			}
@@ -99,18 +91,41 @@ class TaskOrchestrator(
 	}
 
 	private fun handleError(taskId: Long, e: MockWorkerException) {
-		var current = taskService.getTask(taskId)
-		if (e.isTransient && current.retryCount < maxRetryCount) {
-			current.retryCount++
-			current.transitionTo(TaskStatus.FAILED)
-			current = taskService.updateTask(current)
-			log.warn("작업 {} 일시적 오류 (재시도 {}/{}): {}", taskId, current.retryCount, maxRetryCount, e.message)
+		when (e.recoveryAction) {
+			RecoveryAction.RETRY -> {
+				val current = taskService.getTask(taskId)
+				if (current.retryCount < maxRetryCount) {
+					current.retryCount++
+					current.transitionTo(TaskStatus.FAILED)
+					val updated = taskService.updateTask(current)
+					log.warn("작업 {} 일시적 오류 (재시도 {}/{}): {}", taskId, updated.retryCount, maxRetryCount, e.message)
 
-			current.transitionTo(TaskStatus.PENDING)
-			current = taskService.updateTask(current)
-			submitAsync(current)
-		} else {
-			failTask(taskId, "HTTP_${e.upstreamHttpStatus}", e.errorBody)
+					updated.transitionTo(TaskStatus.PENDING)
+					val pending = taskService.updateTask(updated)
+					submitAsync(pending)
+				} else {
+					failTask(
+						taskId,
+						ErrorCode.EXTERNAL_HTTP_ERROR.code,
+						ErrorCode.EXTERNAL_HTTP_ERROR.message(e.upstreamHttpStatus),
+					)
+				}
+			}
+			RecoveryAction.REVERT_TO_PENDING -> {
+				val current = taskService.getTask(taskId)
+				current.externalJobId = null
+				current.transitionTo(TaskStatus.PENDING)
+				val updated = taskService.updateTask(current)
+				submitAsync(updated)
+				log.warn("작업 {} 404 응답 - PENDING 복귀", taskId)
+			}
+			RecoveryAction.FAIL -> {
+				failTask(
+					taskId,
+					ErrorCode.EXTERNAL_HTTP_ERROR.code,
+					ErrorCode.EXTERNAL_HTTP_ERROR.message(e.upstreamHttpStatus),
+				)
+			}
 		}
 	}
 

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/service/TaskRecoveryService.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/service/TaskRecoveryService.kt
@@ -2,6 +2,7 @@ package org.sampletask.foreign_api_sample.task.service
 
 import kotlinx.coroutines.runBlocking
 import org.sampletask.foreign_api_sample.task.client.MockWorkerClient
+import org.sampletask.foreign_api_sample.task.domain.RecoveryAction
 import org.sampletask.foreign_api_sample.task.domain.TaskStatus
 import org.sampletask.foreign_api_sample.task.entity.mapper.TaskMapper
 import org.sampletask.foreign_api_sample.task.exception.MockWorkerException
@@ -74,7 +75,7 @@ class TaskRecoveryService(
 					}
 				}
 			} catch (e: MockWorkerException) {
-				if (e.upstreamHttpStatus == 404) {
+				if (e.recoveryAction == RecoveryAction.REVERT_TO_PENDING) {
 					log.warn("작업 {} 의 외부 Job 404 - PENDING 복귀", task.id)
 					task.externalJobId = null
 					task.transitionTo(TaskStatus.PENDING)

--- a/src/test/kotlin/org/sampletask/foreign_api_sample/common/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/org/sampletask/foreign_api_sample/common/GlobalExceptionHandlerTest.kt
@@ -39,7 +39,10 @@ class GlobalExceptionHandlerTest {
 
 	@Test
 	fun `MockWorkerException은_502_반환`() {
-		val response = handler.handleSystemException(MockWorkerException(500, "error", true))
+		val response =
+			handler.handleSystemException(
+				MockWorkerException(500, "error", org.sampletask.foreign_api_sample.task.domain.RecoveryAction.RETRY),
+			)
 		assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_GATEWAY)
 		assertThat(response.body?.code).isEqualTo("EXTERNAL_SERVICE_ERROR")
 	}

--- a/src/test/kotlin/org/sampletask/foreign_api_sample/task/client/MockWorkerClientTest.kt
+++ b/src/test/kotlin/org/sampletask/foreign_api_sample/task/client/MockWorkerClientTest.kt
@@ -17,7 +17,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.sampletask.foreign_api_sample.task.domain.RecoveryAction
 import org.sampletask.foreign_api_sample.task.exception.MockWorkerException
 import org.springframework.web.reactive.function.client.WebClient
 
@@ -34,7 +36,6 @@ class MockWorkerClientTest {
 		val webClient = WebClient.builder().baseUrl(wireMockServer.baseUrl()).build()
 		apiKeyManager = ApiKeyManager(webClient, "test-candidate", "test@example.com")
 
-		// API Key 발급 stub
 		wireMockServer.stubFor(
 			post(urlEqualTo("/mock/auth/issue-key"))
 				.willReturn(
@@ -96,39 +97,116 @@ class MockWorkerClientTest {
 		}
 	}
 
-	@Test
-	fun `500_에러_시_MockWorkerException_발생_(transient)`() {
-		wireMockServer.stubFor(
-			post(urlEqualTo("/mock/process"))
-				.willReturn(aResponse().withStatus(500).withBody("Internal Server Error")),
-		)
+	@Nested
+	@Suppress("ClassName")
+	inner class 복구액션매핑 {
 
-		assertThatThrownBy {
-			kotlinx.coroutines.runBlocking { mockWorkerClient.submitProcess("https://example.com/image.png") }
+		@Test
+		fun `500_에러_시_RETRY`() {
+			wireMockServer.stubFor(
+				post(urlEqualTo("/mock/process"))
+					.willReturn(aResponse().withStatus(500).withBody("Internal Server Error")),
+			)
+
+			assertThatThrownBy {
+				kotlinx.coroutines.runBlocking { mockWorkerClient.submitProcess("https://example.com/image.png") }
+			}
+				.isInstanceOf(MockWorkerException::class.java)
+				.satisfies({
+					val ex = it as MockWorkerException
+					assertThat(ex.recoveryAction).isEqualTo(RecoveryAction.RETRY)
+					assertThat(ex.upstreamHttpStatus).isEqualTo(500)
+				})
 		}
-			.isInstanceOf(MockWorkerException::class.java)
-			.satisfies({
-				val ex = it as MockWorkerException
-				assertThat(ex.isTransient).isTrue()
-				assertThat(ex.upstreamHttpStatus).isEqualTo(500)
-			})
-	}
 
-	@Test
-	fun `400_에러_시_MockWorkerException_발생_(permanent)`() {
-		wireMockServer.stubFor(
-			post(urlEqualTo("/mock/process"))
-				.willReturn(aResponse().withStatus(400).withBody("Bad Request")),
-		)
+		@Test
+		fun `429_에러_시_RETRY`() {
+			wireMockServer.stubFor(
+				post(urlEqualTo("/mock/process"))
+					.willReturn(aResponse().withStatus(429).withBody("Too Many Requests")),
+			)
 
-		assertThatThrownBy {
-			kotlinx.coroutines.runBlocking { mockWorkerClient.submitProcess("https://example.com/image.png") }
+			assertThatThrownBy {
+				kotlinx.coroutines.runBlocking { mockWorkerClient.submitProcess("https://example.com/image.png") }
+			}
+				.isInstanceOf(MockWorkerException::class.java)
+				.satisfies({
+					val ex = it as MockWorkerException
+					assertThat(ex.recoveryAction).isEqualTo(RecoveryAction.RETRY)
+					assertThat(ex.upstreamHttpStatus).isEqualTo(429)
+				})
 		}
-			.isInstanceOf(MockWorkerException::class.java)
-			.satisfies({
-				val ex = it as MockWorkerException
-				assertThat(ex.isTransient).isFalse()
-				assertThat(ex.upstreamHttpStatus).isEqualTo(400)
-			})
+
+		@Test
+		fun `503_에러_시_RETRY`() {
+			wireMockServer.stubFor(
+				post(urlEqualTo("/mock/process"))
+					.willReturn(aResponse().withStatus(503).withBody("Service Unavailable")),
+			)
+
+			assertThatThrownBy {
+				kotlinx.coroutines.runBlocking { mockWorkerClient.submitProcess("https://example.com/image.png") }
+			}
+				.isInstanceOf(MockWorkerException::class.java)
+				.satisfies({
+					val ex = it as MockWorkerException
+					assertThat(ex.recoveryAction).isEqualTo(RecoveryAction.RETRY)
+					assertThat(ex.upstreamHttpStatus).isEqualTo(503)
+				})
+		}
+
+		@Test
+		fun `400_에러_시_FAIL`() {
+			wireMockServer.stubFor(
+				post(urlEqualTo("/mock/process"))
+					.willReturn(aResponse().withStatus(400).withBody("Bad Request")),
+			)
+
+			assertThatThrownBy {
+				kotlinx.coroutines.runBlocking { mockWorkerClient.submitProcess("https://example.com/image.png") }
+			}
+				.isInstanceOf(MockWorkerException::class.java)
+				.satisfies({
+					val ex = it as MockWorkerException
+					assertThat(ex.recoveryAction).isEqualTo(RecoveryAction.FAIL)
+					assertThat(ex.upstreamHttpStatus).isEqualTo(400)
+				})
+		}
+
+		@Test
+		fun `422_에러_시_FAIL`() {
+			wireMockServer.stubFor(
+				post(urlEqualTo("/mock/process"))
+					.willReturn(aResponse().withStatus(422).withBody("Unprocessable Entity")),
+			)
+
+			assertThatThrownBy {
+				kotlinx.coroutines.runBlocking { mockWorkerClient.submitProcess("https://example.com/image.png") }
+			}
+				.isInstanceOf(MockWorkerException::class.java)
+				.satisfies({
+					val ex = it as MockWorkerException
+					assertThat(ex.recoveryAction).isEqualTo(RecoveryAction.FAIL)
+					assertThat(ex.upstreamHttpStatus).isEqualTo(422)
+				})
+		}
+
+		@Test
+		fun `404_에러_시_REVERT_TO_PENDING`() {
+			wireMockServer.stubFor(
+				get(urlEqualTo("/mock/process/job-404"))
+					.willReturn(aResponse().withStatus(404).withBody("Not Found")),
+			)
+
+			assertThatThrownBy {
+				kotlinx.coroutines.runBlocking { mockWorkerClient.getJobStatus("job-404") }
+			}
+				.isInstanceOf(MockWorkerException::class.java)
+				.satisfies({
+					val ex = it as MockWorkerException
+					assertThat(ex.recoveryAction).isEqualTo(RecoveryAction.REVERT_TO_PENDING)
+					assertThat(ex.upstreamHttpStatus).isEqualTo(404)
+				})
+		}
 	}
 }

--- a/src/test/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestratorTest.kt
+++ b/src/test/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestratorTest.kt
@@ -1,11 +1,12 @@
 package org.sampletask.foreign_api_sample.task.service
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
@@ -15,6 +16,7 @@ import org.mockito.kotlin.whenever
 import org.sampletask.foreign_api_sample.task.client.MockWorkerClient
 import org.sampletask.foreign_api_sample.task.client.response.JobStatusResponse
 import org.sampletask.foreign_api_sample.task.client.response.ProcessResponse
+import org.sampletask.foreign_api_sample.task.domain.RecoveryAction
 import org.sampletask.foreign_api_sample.task.domain.Task
 import org.sampletask.foreign_api_sample.task.domain.TaskStatus
 import org.sampletask.foreign_api_sample.task.exception.MockWorkerException
@@ -40,7 +42,7 @@ class TaskOrchestratorTest {
 
 	@BeforeEach
 	fun setUp() {
-		val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+		val scope = CoroutineScope(SupervisorJob() + StandardTestDispatcher())
 		orchestrator =
 			TaskOrchestrator(
 				taskService = taskService,
@@ -53,7 +55,7 @@ class TaskOrchestratorTest {
 	}
 
 	@Test
-	fun `정상_처리_흐름_-_PENDING에서_COMPLETED`() {
+	fun `정상_처리_흐름_PENDING에서_COMPLETED`() {
 		runTest {
 			val task = createTask()
 
@@ -90,36 +92,78 @@ class TaskOrchestratorTest {
 		}
 	}
 
-	@Test
-	fun `transient_에러_시_재시도`() {
-		runTest {
-			val task = createTask()
+	@Nested
+	@Suppress("ClassName")
+	inner class 복구액션별에러처리 {
 
-			whenever(taskService.getTask(1L)).thenReturn(task)
-			whenever(taskService.updateTask(any())).thenAnswer { it.arguments[0] as Task }
-			whenever(mockWorkerClient.submitProcess(any()))
-				.thenThrow(MockWorkerException(500, "Internal Server Error", true))
+		@Test
+		fun `RETRY_재시도_횟수_미만이면_PENDING_복귀_후_재시도`() {
+			runTest {
+				val task = createTask()
 
-			orchestrator.processTask(task)
+				whenever(taskService.getTask(1L)).thenReturn(task)
+				whenever(taskService.updateTask(any())).thenAnswer { it.arguments[0] as Task }
+				whenever(mockWorkerClient.submitProcess(any()))
+					.thenThrow(MockWorkerException(500, "Internal Server Error", RecoveryAction.RETRY))
 
-			assertThat(task.retryCount).isEqualTo(1)
+				orchestrator.processTask(task)
+
+				assertThat(task.retryCount).isEqualTo(1)
+				assertThat(task.status).isEqualTo(TaskStatus.PENDING)
+			}
 		}
-	}
 
-	@Test
-	fun `permanent_에러_시_즉시_FAILED`() {
-		runTest {
-			val task = createTask()
+		@Test
+		fun `RETRY_재시도_횟수_초과_시_FAILED`() {
+			runTest {
+				val task = createTask()
+				task.retryCount = 3
 
-			whenever(taskService.getTask(1L)).thenReturn(task)
-			whenever(taskService.updateTask(any())).thenAnswer { it.arguments[0] as Task }
-			whenever(mockWorkerClient.submitProcess(any()))
-				.thenThrow(MockWorkerException(400, "Bad Request", false))
+				whenever(taskService.getTask(1L)).thenReturn(task)
+				whenever(taskService.updateTask(any())).thenAnswer { it.arguments[0] as Task }
+				whenever(mockWorkerClient.submitProcess(any()))
+					.thenThrow(MockWorkerException(500, "Internal Server Error", RecoveryAction.RETRY))
 
-			orchestrator.processTask(task)
+				orchestrator.processTask(task)
 
-			assertThat(task.status).isEqualTo(TaskStatus.FAILED)
-			assertThat(task.errorCode).isEqualTo("HTTP_400")
+				assertThat(task.status).isEqualTo(TaskStatus.FAILED)
+				assertThat(task.errorCode).isEqualTo("EXTERNAL_HTTP_ERROR")
+			}
+		}
+
+		@Test
+		fun `FAIL_즉시_FAILED_처리`() {
+			runTest {
+				val task = createTask()
+
+				whenever(taskService.getTask(1L)).thenReturn(task)
+				whenever(taskService.updateTask(any())).thenAnswer { it.arguments[0] as Task }
+				whenever(mockWorkerClient.submitProcess(any()))
+					.thenThrow(MockWorkerException(400, "Bad Request", RecoveryAction.FAIL))
+
+				orchestrator.processTask(task)
+
+				assertThat(task.status).isEqualTo(TaskStatus.FAILED)
+				assertThat(task.errorCode).isEqualTo("EXTERNAL_HTTP_ERROR")
+			}
+		}
+
+		@Test
+		fun `REVERT_TO_PENDING_externalJobId_초기화_후_PENDING_복귀`() {
+			runTest {
+				val task = createTask(status = TaskStatus.PENDING)
+				task.externalJobId = "job-123"
+
+				whenever(taskService.getTask(1L)).thenReturn(task)
+				whenever(taskService.updateTask(any())).thenAnswer { it.arguments[0] as Task }
+				whenever(mockWorkerClient.submitProcess(any()))
+					.thenThrow(MockWorkerException(404, "Not Found", RecoveryAction.REVERT_TO_PENDING))
+
+				orchestrator.processTask(task)
+
+				assertThat(task.externalJobId).isNull()
+				assertThat(task.status).isEqualTo(TaskStatus.PENDING)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## 작업 내역

- `RecoveryAction` enum 도입 (`RETRY`, `FAIL`, `REVERT_TO_PENDING`)으로 HTTP 상태 코드별 복구 전략 분리
- `MockWorkerException`의 `isTransient: Boolean` → `recoveryAction: RecoveryAction`으로 변경
- `MockWorkerClient.toMockWorkerException()`에서 상태 코드별 `RecoveryAction` 매핑
  - 404 → `REVERT_TO_PENDING`
  - 429, 500, 502, 503, 504 → `RETRY`
  - 그 외 → `FAIL`
- `TaskOrchestrator.handleError()`를 `when(recoveryAction)` 기반으로 리팩토링
  - `RETRY`: 재시도 횟수 미만이면 PENDING 복귀 후 재제출, 초과 시 FAILED
  - `REVERT_TO_PENDING`: externalJobId 초기화 후 PENDING 복귀
  - `FAIL`: 즉시 FAILED 처리
- `TaskRecoveryService`에서 404 직접 비교 → `RecoveryAction.REVERT_TO_PENDING` 비교로 변경
- `ErrorCode.EXTERNAL_HTTP_ERROR` 추가, 에러 코드 `HTTP_{status}` → `EXTERNAL_HTTP_ERROR`로 통일
- 단위 테스트 보강: `MockWorkerClientTest`, `TaskOrchestratorTest`에 `RecoveryAction`별 케이스 추가

Closes #47