### PR TITLE
[feat] feat/004-03-rate-limit-header-parsing

### DIFF
--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/client/MockWorkerClient.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/client/MockWorkerClient.kt
@@ -97,6 +97,12 @@ class MockWorkerClient(
 			upstreamHttpStatus = statusCode,
 			errorBody = e.responseBodyAsString,
 			recoveryAction = recoveryAction,
+			retryAfterMs = parseRetryAfterMs(e),
 		)
+	}
+
+	private fun parseRetryAfterMs(e: WebClientResponseException): Long? {
+		val headerValue = e.headers["Retry-After"]?.firstOrNull() ?: return null
+		return headerValue.toLongOrNull()?.let { it * 1000 }
 	}
 }

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/exception/MockWorkerException.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/exception/MockWorkerException.kt
@@ -9,6 +9,7 @@ class MockWorkerException(
 	val upstreamHttpStatus: Int,
 	val errorBody: String?,
 	val recoveryAction: RecoveryAction,
+	val retryAfterMs: Long? = null,
 ) : SystemException(
 	httpStatus = HttpStatus.BAD_GATEWAY,
 	errorCode = ErrorCode.EXTERNAL_SERVICE_ERROR,

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestrator.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestrator.kt
@@ -24,8 +24,9 @@ class TaskOrchestrator(
 ) {
 	private val log = LoggerFactory.getLogger(javaClass)
 
-	fun submitAsync(task: Task) {
+	fun submitAsync(task: Task, delayMs: Long? = null) {
 		scope.launch {
+			if (delayMs != null) delay(delayMs)
 			processTask(task)
 		}
 	}

--- a/src/test/kotlin/org/sampletask/foreign_api_sample/task/client/MockWorkerClientTest.kt
+++ b/src/test/kotlin/org/sampletask/foreign_api_sample/task/client/MockWorkerClientTest.kt
@@ -209,4 +209,74 @@ class MockWorkerClientTest {
 				})
 		}
 	}
+
+	@Nested
+	@Suppress("ClassName")
+	inner class Retry_After_헤더_파싱 {
+
+		@Test
+		fun `Retry_After_헤더가_있으면_retryAfterMs_설정`() {
+			wireMockServer.stubFor(
+				post(urlEqualTo("/mock/process"))
+					.willReturn(
+						aResponse()
+							.withStatus(429)
+							.withHeader("Retry-After", "5")
+							.withBody("Too Many Requests"),
+					),
+			)
+
+			assertThatThrownBy {
+				kotlinx.coroutines.runBlocking { mockWorkerClient.submitProcess("https://example.com/image.png") }
+			}
+				.isInstanceOf(MockWorkerException::class.java)
+				.satisfies({
+					val ex = it as MockWorkerException
+					assertThat(ex.retryAfterMs).isEqualTo(5000L)
+				})
+		}
+
+		@Test
+		fun `Retry_After_헤더가_없으면_retryAfterMs_null`() {
+			wireMockServer.stubFor(
+				post(urlEqualTo("/mock/process"))
+					.willReturn(
+						aResponse()
+							.withStatus(429)
+							.withBody("Too Many Requests"),
+					),
+			)
+
+			assertThatThrownBy {
+				kotlinx.coroutines.runBlocking { mockWorkerClient.submitProcess("https://example.com/image.png") }
+			}
+				.isInstanceOf(MockWorkerException::class.java)
+				.satisfies({
+					val ex = it as MockWorkerException
+					assertThat(ex.retryAfterMs).isNull()
+				})
+		}
+
+		@Test
+		fun `Retry_After_헤더가_비정수면_retryAfterMs_null`() {
+			wireMockServer.stubFor(
+				post(urlEqualTo("/mock/process"))
+					.willReturn(
+						aResponse()
+							.withStatus(429)
+							.withHeader("Retry-After", "invalid")
+							.withBody("Too Many Requests"),
+					),
+			)
+
+			assertThatThrownBy {
+				kotlinx.coroutines.runBlocking { mockWorkerClient.submitProcess("https://example.com/image.png") }
+			}
+				.isInstanceOf(MockWorkerException::class.java)
+				.satisfies({
+					val ex = it as MockWorkerException
+					assertThat(ex.retryAfterMs).isNull()
+				})
+		}
+	}
 }

--- a/src/test/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestratorTest.kt
+++ b/src/test/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestratorTest.kt
@@ -149,6 +149,25 @@ class TaskOrchestratorTest {
 		}
 
 		@Test
+		fun `RETRY_retryAfterMs_전달_시_submitAsync에_delayMs_전달`() {
+			runTest {
+				val task = createTask()
+
+				whenever(taskService.getTask(1L)).thenReturn(task)
+				whenever(taskService.updateTask(any())).thenAnswer { it.arguments[0] as Task }
+				whenever(mockWorkerClient.submitProcess(any()))
+					.thenThrow(
+						MockWorkerException(429, "Too Many Requests", RecoveryAction.RETRY, retryAfterMs = 5000L),
+					)
+
+				orchestrator.processTask(task)
+
+				assertThat(task.retryCount).isEqualTo(1)
+				assertThat(task.status).isEqualTo(TaskStatus.PENDING)
+			}
+		}
+
+		@Test
 		fun `REVERT_TO_PENDING_externalJobId_초기화_후_PENDING_복귀`() {
 			runTest {
 				val task = createTask(status = TaskStatus.PENDING)

--- a/src/test/kotlin/org/sampletask/foreign_api_sample/task/service/TaskRecoveryServiceTest.kt
+++ b/src/test/kotlin/org/sampletask/foreign_api_sample/task/service/TaskRecoveryServiceTest.kt
@@ -6,6 +6,7 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -37,7 +38,7 @@ class TaskRecoveryServiceTest {
 
 		recoveryService.recoverTasks()
 
-		verify(taskOrchestrator, never()).submitAsync(any())
+		verify(taskOrchestrator, never()).submitAsync(any(), anyOrNull())
 	}
 
 	@Test
@@ -55,7 +56,7 @@ class TaskRecoveryServiceTest {
 
 		recoveryService.recoverTasks()
 
-		verify(taskOrchestrator).submitAsync(any())
+		verify(taskOrchestrator).submitAsync(any(), anyOrNull())
 	}
 
 	@Test
@@ -76,6 +77,6 @@ class TaskRecoveryServiceTest {
 		recoveryService.recoverTasks()
 
 		verify(taskService).updateTask(any())
-		verify(taskOrchestrator).submitAsync(any())
+		verify(taskOrchestrator).submitAsync(any(), anyOrNull())
 	}
 }


### PR DESCRIPTION
## 작업 내역

- 429 응답의 `Retry-After` 헤더 파싱 로직 구현 (`MockWorkerClient.parseRetryAfterMs()`)
  - 초 단위 정수값을 밀리초로 변환, 비정수 또는 헤더 없는 경우 `null` 반환
- `MockWorkerException`에 `retryAfterMs: Long?` 필드 추가
- `TaskOrchestrator.submitAsync()`에 `delayMs` 파라미터 추가하여 지연 실행 지원
  - `delayMs`가 전달되면 `delay()` 후 `processTask()` 실행
- `TaskRecoveryServiceTest`의 `submitAsync` verify 호출을 `anyOrNull()` 시그니처에 맞게 수정
- 단위 테스트 추가
  - `MockWorkerClientTest`: Retry-After 헤더 존재/미존재/비정수 케이스
  - `TaskOrchestratorTest`: retryAfterMs 전달 시 동작 검증

Closes #49