### PR TITLE
[feat] feat/004-02-recovery-service-async

### DIFF
--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/service/TaskRecoveryService.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/service/TaskRecoveryService.kt
@@ -1,8 +1,10 @@
 package org.sampletask.foreign_api_sample.task.service
 
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import org.sampletask.foreign_api_sample.task.client.MockWorkerClient
 import org.sampletask.foreign_api_sample.task.domain.RecoveryAction
+import org.sampletask.foreign_api_sample.task.domain.Task
 import org.sampletask.foreign_api_sample.task.domain.TaskStatus
 import org.sampletask.foreign_api_sample.task.entity.mapper.TaskMapper
 import org.sampletask.foreign_api_sample.task.exception.MockWorkerException
@@ -18,6 +20,7 @@ class TaskRecoveryService(
 	private val taskService: TaskService,
 	private val taskOrchestrator: TaskOrchestrator,
 	private val mockWorkerClient: MockWorkerClient,
+	private val scope: CoroutineScope,
 ) {
 	private val log = LoggerFactory.getLogger(javaClass)
 
@@ -49,10 +52,10 @@ class TaskRecoveryService(
 		}
 	}
 
-	private fun recoverProcessingTask(task: org.sampletask.foreign_api_sample.task.domain.Task) {
+	private fun recoverProcessingTask(task: Task) {
 		if (task.externalJobId != null) {
-			try {
-				runBlocking {
+			scope.launch {
+				try {
 					val status = mockWorkerClient.getJobStatus(task.externalJobId!!)
 					when (status.status) {
 						"COMPLETED" -> {
@@ -73,21 +76,21 @@ class TaskRecoveryService(
 							taskOrchestrator.submitAsync(task)
 						}
 					}
-				}
-			} catch (e: MockWorkerException) {
-				if (e.recoveryAction == RecoveryAction.REVERT_TO_PENDING) {
-					log.warn("작업 {} 의 외부 Job 404 - PENDING 복귀", task.id)
-					task.externalJobId = null
-					task.transitionTo(TaskStatus.PENDING)
-					taskService.updateTask(task)
+				} catch (e: MockWorkerException) {
+					if (e.recoveryAction == RecoveryAction.REVERT_TO_PENDING) {
+						log.warn("작업 {} 의 외부 Job 404 - PENDING 복귀", task.id)
+						task.externalJobId = null
+						task.transitionTo(TaskStatus.PENDING)
+						taskService.updateTask(task)
+						taskOrchestrator.submitAsync(task)
+					} else {
+						log.error("작업 {} 복구 중 오류: {}", task.id, e.message)
+						taskOrchestrator.submitAsync(task)
+					}
+				} catch (e: Exception) {
+					log.error("작업 {} 복구 중 예상치 못한 오류: {}", task.id, e.message, e)
 					taskOrchestrator.submitAsync(task)
-				} else {
-					log.error("작업 {} 복구 중 오류: {}", task.id, e.message)
-					taskOrchestrator.submitAsync(task)
 				}
-			} catch (e: Exception) {
-				log.error("작업 {} 복구 중 예상치 못한 오류: {}", task.id, e.message, e)
-				taskOrchestrator.submitAsync(task)
 			}
 		} else {
 			log.info("PROCESSING 작업 {} 에 jobId 없음 - PENDING 복귀", task.id)

--- a/src/test/kotlin/org/sampletask/foreign_api_sample/task/service/TaskRecoveryServiceTest.kt
+++ b/src/test/kotlin/org/sampletask/foreign_api_sample/task/service/TaskRecoveryServiceTest.kt
@@ -1,8 +1,14 @@
 package org.sampletask.foreign_api_sample.task.service
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
@@ -10,11 +16,16 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.sampletask.foreign_api_sample.task.client.MockWorkerClient
+import org.sampletask.foreign_api_sample.task.client.response.JobStatusResponse
+import org.sampletask.foreign_api_sample.task.domain.RecoveryAction
 import org.sampletask.foreign_api_sample.task.domain.TaskStatus
 import org.sampletask.foreign_api_sample.task.entity.TaskEntity
+import org.sampletask.foreign_api_sample.task.exception.MockWorkerException
 import org.sampletask.foreign_api_sample.task.repository.TaskRepository
 import java.time.Instant
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(MockitoExtension::class)
 class TaskRecoveryServiceTest {
 	@Mock
@@ -27,56 +38,163 @@ class TaskRecoveryServiceTest {
 	private lateinit var taskOrchestrator: TaskOrchestrator
 
 	@Mock
-	private lateinit var mockWorkerClient: org.sampletask.foreign_api_sample.task.client.MockWorkerClient
+	private lateinit var mockWorkerClient: MockWorkerClient
 
-	@InjectMocks
 	private lateinit var recoveryService: TaskRecoveryService
 
-	@Test
-	fun `복구_대상_없으면_아무것도_하지_않음`() {
-		whenever(taskRepository.findAllByStatusIn(any())).thenReturn(emptyList())
-
-		recoveryService.recoverTasks()
-
-		verify(taskOrchestrator, never()).submitAsync(any(), anyOrNull())
+	@BeforeEach
+	fun setUp() {
+		val scope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())
+		recoveryService =
+			TaskRecoveryService(
+				taskRepository = taskRepository,
+				taskService = taskService,
+				taskOrchestrator = taskOrchestrator,
+				mockWorkerClient = mockWorkerClient,
+				scope = scope,
+			)
 	}
 
-	@Test
-	fun `PENDING_작업은_Orchestrator에_재등록`() {
-		val entity =
-			TaskEntity(
-				id = 1L,
-				status = TaskStatus.PENDING.code,
-				idempotencyKey = "key-1",
-				imageUrl = "https://example.com/image.png",
-				createdAt = Instant.now(),
-				updatedAt = Instant.now(),
-			)
-		whenever(taskRepository.findAllByStatusIn(any())).thenReturn(listOf(entity))
+	@Nested
+	@Suppress("ClassName")
+	inner class 복구_대상_없음 {
 
-		recoveryService.recoverTasks()
+		@Test
+		fun `복구_대상_없으면_아무것도_하지_않음`() {
+			whenever(taskRepository.findAllByStatusIn(any())).thenReturn(emptyList())
 
-		verify(taskOrchestrator).submitAsync(any(), anyOrNull())
+			recoveryService.recoverTasks()
+
+			verify(taskOrchestrator, never()).submitAsync(any(), anyOrNull())
+		}
 	}
 
-	@Test
-	fun `PROCESSING_작업(jobId_없음)은_PENDING_복귀_후_재등록`() {
-		val entity =
-			TaskEntity(
-				id = 2L,
-				status = TaskStatus.PROCESSING.code,
-				idempotencyKey = "key-2",
-				imageUrl = "https://example.com/image.png",
-				externalJobId = null,
-				createdAt = Instant.now(),
-				updatedAt = Instant.now(),
-			)
-		whenever(taskRepository.findAllByStatusIn(any())).thenReturn(listOf(entity))
-		whenever(taskService.updateTask(any())).thenAnswer { it.arguments[0] }
+	@Nested
+	@Suppress("ClassName")
+	inner class PENDING_작업_복구 {
 
-		recoveryService.recoverTasks()
+		@Test
+		fun `PENDING_작업은_Orchestrator에_재등록`() {
+			val entity = createEntity(id = 1L, status = TaskStatus.PENDING)
+			whenever(taskRepository.findAllByStatusIn(any())).thenReturn(listOf(entity))
 
-		verify(taskService).updateTask(any())
-		verify(taskOrchestrator).submitAsync(any(), anyOrNull())
+			recoveryService.recoverTasks()
+
+			verify(taskOrchestrator).submitAsync(any(), anyOrNull())
+		}
+	}
+
+	@Nested
+	@Suppress("ClassName")
+	inner class PROCESSING_작업_복구 {
+
+		@Test
+		fun `jobId_없으면_PENDING_복귀_후_재등록`() {
+			val entity = createEntity(id = 2L, status = TaskStatus.PROCESSING, externalJobId = null)
+			whenever(taskRepository.findAllByStatusIn(any())).thenReturn(listOf(entity))
+			whenever(taskService.updateTask(any())).thenAnswer { it.arguments[0] }
+
+			recoveryService.recoverTasks()
+
+			verify(taskService).updateTask(any())
+			verify(taskOrchestrator).submitAsync(any(), anyOrNull())
+		}
+
+		@Test
+		fun `외부_상태_COMPLETED면_작업_완료_처리`() {
+			runTest {
+				val entity = createEntity(id = 3L, status = TaskStatus.PROCESSING, externalJobId = "job-3")
+				whenever(taskRepository.findAllByStatusIn(any())).thenReturn(listOf(entity))
+				whenever(taskService.updateTask(any())).thenAnswer { it.arguments[0] }
+				whenever(mockWorkerClient.getJobStatus("job-3")).thenReturn(
+					JobStatusResponse(jobId = "job-3", status = "COMPLETED", result = "done"),
+				)
+
+				recoveryService.recoverTasks()
+
+				verify(taskService).updateTask(
+					org.mockito.kotlin.argThat { status == TaskStatus.COMPLETED },
+				)
+			}
+		}
+
+		@Test
+		fun `외부_상태_FAILED면_작업_실패_처리`() {
+			runTest {
+				val entity = createEntity(id = 4L, status = TaskStatus.PROCESSING, externalJobId = "job-4")
+				whenever(taskRepository.findAllByStatusIn(any())).thenReturn(listOf(entity))
+				whenever(taskService.updateTask(any())).thenAnswer { it.arguments[0] }
+				whenever(mockWorkerClient.getJobStatus("job-4")).thenReturn(
+					JobStatusResponse(jobId = "job-4", status = "FAILED", errorCode = "ERR", errorMessage = "fail"),
+				)
+
+				recoveryService.recoverTasks()
+
+				verify(taskService).updateTask(
+					org.mockito.kotlin.argThat { status == TaskStatus.FAILED },
+				)
+			}
+		}
+
+		@Test
+		fun `외부_상태_PROCESSING이면_폴링_재개`() {
+			runTest {
+				val entity = createEntity(id = 5L, status = TaskStatus.PROCESSING, externalJobId = "job-5")
+				whenever(taskRepository.findAllByStatusIn(any())).thenReturn(listOf(entity))
+				whenever(mockWorkerClient.getJobStatus("job-5")).thenReturn(
+					JobStatusResponse(jobId = "job-5", status = "PROCESSING"),
+				)
+
+				recoveryService.recoverTasks()
+
+				verify(taskOrchestrator).submitAsync(any(), anyOrNull())
+			}
+		}
+
+		@Test
+		fun `외부_조회_404_시_PENDING_복귀`() {
+			runTest {
+				val entity = createEntity(id = 6L, status = TaskStatus.PROCESSING, externalJobId = "job-6")
+				whenever(taskRepository.findAllByStatusIn(any())).thenReturn(listOf(entity))
+				whenever(taskService.updateTask(any())).thenAnswer { it.arguments[0] }
+				whenever(mockWorkerClient.getJobStatus("job-6"))
+					.thenThrow(MockWorkerException(404, "Not Found", RecoveryAction.REVERT_TO_PENDING))
+
+				recoveryService.recoverTasks()
+
+				verify(taskService).updateTask(
+					org.mockito.kotlin.argThat {
+						externalJobId == null && status == TaskStatus.PENDING
+					},
+				)
+				verify(taskOrchestrator).submitAsync(any(), anyOrNull())
+			}
+		}
+
+		@Test
+		fun `외부_조회_기타_오류_시_폴링_재개`() {
+			runTest {
+				val entity = createEntity(id = 7L, status = TaskStatus.PROCESSING, externalJobId = "job-7")
+				whenever(taskRepository.findAllByStatusIn(any())).thenReturn(listOf(entity))
+				whenever(mockWorkerClient.getJobStatus("job-7"))
+					.thenThrow(MockWorkerException(500, "Server Error", RecoveryAction.RETRY))
+
+				recoveryService.recoverTasks()
+
+				verify(taskOrchestrator).submitAsync(any(), anyOrNull())
+			}
+		}
+	}
+
+	private fun createEntity(id: Long, status: TaskStatus, externalJobId: String? = null): TaskEntity {
+		return TaskEntity(
+			id = id,
+			status = status.code,
+			idempotencyKey = "key-$id",
+			imageUrl = "https://example.com/image.png",
+			externalJobId = externalJobId,
+			createdAt = Instant.now(),
+			updatedAt = Instant.now(),
+		)
 	}
 }


### PR DESCRIPTION
## 작업 내역

- `TaskRecoveryService`에서 `runBlocking` 제거, `CoroutineScope.launch` 기반 비동기 복구로 전환
- `CoroutineScope`를 생성자 주입으로 변경하여 테스트 용이성 확보
- `recoverProcessingTask()` 내부의 try-catch를 코루틴 내부로 이동
- 기타 오류 발생 시에도 `submitAsync()`로 폴링 재개하도록 처리
- 단위 테스트 대폭 보강 (`@Nested` 구조화, `UnconfinedTestDispatcher` 적용)
  - PENDING 작업 재등록, PROCESSING 작업의 외부 상태별 처리 (COMPLETED/FAILED/PROCESSING)
  - 외부 조회 404 시 PENDING 복귀, 기타 오류 시 폴링 재개
- `createEntity()` 헬퍼 메서드로 테스트 코드 중복 제거

Closes #48