### PR TITLE
[feat] feat/005-01-polling-backoff-jitter

### DIFF
--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestrator.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestrator.kt
@@ -21,6 +21,7 @@ class TaskOrchestrator(
 	@Value("\${task.max-retry-count:3}") private val maxRetryCount: Int,
 	@Value("\${task.polling.initial-interval-ms:2000}") private val initialIntervalMs: Long,
 	@Value("\${task.polling.max-interval-ms:10000}") private val maxIntervalMs: Long,
+	@Value("\${task.polling.multiplier:2.0}") private val multiplier: Double,
 ) {
 	private val log = LoggerFactory.getLogger(javaClass)
 
@@ -62,7 +63,8 @@ class TaskOrchestrator(
 		var intervalMs = initialIntervalMs
 
 		while (true) {
-			delay(intervalMs)
+			val jitter = intervalMs * (0.5 + Math.random() * 0.5)
+			delay(jitter.toLong())
 
 			try {
 				val status = mockWorkerClient.getJobStatus(jobId)
@@ -81,7 +83,7 @@ class TaskOrchestrator(
 						return
 					}
 					else -> {
-						intervalMs = (intervalMs * 2).coerceAtMost(maxIntervalMs)
+						intervalMs = (intervalMs * multiplier).toLong().coerceAtMost(maxIntervalMs)
 					}
 				}
 			} catch (e: MockWorkerException) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -42,6 +42,7 @@ task:
   polling:
     initial-interval-ms: 2000
     max-interval-ms: 10000
+    multiplier: 2.0
 
 resilience4j:
   circuitbreaker:

--- a/src/test/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestratorTest.kt
+++ b/src/test/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestratorTest.kt
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.sampletask.foreign_api_sample.task.client.MockWorkerClient
 import org.sampletask.foreign_api_sample.task.client.response.JobStatusResponse
@@ -51,6 +53,7 @@ class TaskOrchestratorTest {
 				maxRetryCount = 3,
 				initialIntervalMs = 10,
 				maxIntervalMs = 50,
+				multiplier = 2.0,
 			)
 	}
 
@@ -182,6 +185,38 @@ class TaskOrchestratorTest {
 
 				assertThat(task.externalJobId).isNull()
 				assertThat(task.status).isEqualTo(TaskStatus.PENDING)
+			}
+		}
+	}
+
+	@Nested
+	@Suppress("ClassName")
+	inner class 폴링_백오프_jitter {
+
+		@Test
+		fun `폴링_2회_이상_시_backoff_적용_확인`() {
+			runTest {
+				val task = createTask()
+
+				whenever(taskService.getTask(1L)).thenReturn(task)
+				whenever(taskService.updateTask(any())).thenAnswer { it.arguments[0] as Task }
+				whenever(mockWorkerClient.submitProcess(any())).thenReturn(ProcessResponse("job-123"))
+				whenever(mockWorkerClient.getJobStatus("job-123"))
+					.thenReturn(
+						JobStatusResponse(jobId = "job-123", status = "PROCESSING"),
+					)
+					.thenReturn(
+						JobStatusResponse(jobId = "job-123", status = "PROCESSING"),
+					)
+					.thenReturn(
+						JobStatusResponse(jobId = "job-123", status = "COMPLETED", result = "result-data"),
+					)
+
+				orchestrator.processTask(task)
+
+				assertThat(task.status).isEqualTo(TaskStatus.COMPLETED)
+				assertThat(task.result).isEqualTo("result-data")
+				verify(mockWorkerClient, times(3)).getJobStatus("job-123")
 			}
 		}
 	}


### PR DESCRIPTION
## 목표
폴링 backoff multiplier 외부화 및 jitter 적용

## 작업 항목
- application.yaml에 `task.polling.multiplier` 설정 추가
- TaskOrchestrator에 `multiplier` `@Value` 파라미터 추가, 하드코딩 제거
- `pollForResult`에 jitter 적용 (`interval * random(0.5, 1.0)`)
- 폴링 backoff + jitter 검증 테스트 추가

Closes #50