### PR TITLE
[feat] feat/005-02-polling-concurrency-limit

### DIFF
--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestrator.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestrator.kt
@@ -3,6 +3,7 @@ package org.sampletask.foreign_api_sample.task.service
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
 import org.sampletask.foreign_api_sample.common.ErrorCode
 import org.sampletask.foreign_api_sample.task.client.MockWorkerClient
 import org.sampletask.foreign_api_sample.task.domain.RecoveryAction
@@ -22,8 +23,10 @@ class TaskOrchestrator(
 	@Value("\${task.polling.initial-interval-ms:2000}") private val initialIntervalMs: Long,
 	@Value("\${task.polling.max-interval-ms:10000}") private val maxIntervalMs: Long,
 	@Value("\${task.polling.multiplier:2.0}") private val multiplier: Double,
+	@Value("\${task.polling.max-concurrent:5}") private val maxConcurrentPolling: Int,
 ) {
 	private val log = LoggerFactory.getLogger(javaClass)
+	private val pollingSemaphore = Semaphore(maxConcurrentPolling)
 
 	fun submitAsync(task: Task, delayMs: Long? = null) {
 		scope.launch {
@@ -62,34 +65,39 @@ class TaskOrchestrator(
 		val taskId = task.id
 		var intervalMs = initialIntervalMs
 
-		while (true) {
-			val jitter = intervalMs * (0.5 + Math.random() * 0.5)
-			delay(jitter.toLong())
+		pollingSemaphore.acquire()
+		try {
+			while (true) {
+				val jitter = intervalMs * (0.5 + Math.random() * 0.5)
+				delay(jitter.toLong())
 
-			try {
-				val status = mockWorkerClient.getJobStatus(jobId)
+				try {
+					val status = mockWorkerClient.getJobStatus(jobId)
 
-				when (status.status) {
-					"COMPLETED" -> {
-						val current = taskService.getTask(taskId)
-						current.result = status.result
-						current.transitionTo(TaskStatus.COMPLETED)
-						taskService.updateTask(current)
-						log.info("작업 {} 완료", taskId)
-						return
+					when (status.status) {
+						"COMPLETED" -> {
+							val current = taskService.getTask(taskId)
+							current.result = status.result
+							current.transitionTo(TaskStatus.COMPLETED)
+							taskService.updateTask(current)
+							log.info("작업 {} 완료", taskId)
+							return
+						}
+						"FAILED" -> {
+							failTask(taskId, status.errorCode, status.errorMessage)
+							return
+						}
+						else -> {
+							intervalMs = (intervalMs * multiplier).toLong().coerceAtMost(maxIntervalMs)
+						}
 					}
-					"FAILED" -> {
-						failTask(taskId, status.errorCode, status.errorMessage)
-						return
-					}
-					else -> {
-						intervalMs = (intervalMs * multiplier).toLong().coerceAtMost(maxIntervalMs)
-					}
+				} catch (e: MockWorkerException) {
+					handleError(taskId, e)
+					return
 				}
-			} catch (e: MockWorkerException) {
-				handleError(taskId, e)
-				return
 			}
+		} finally {
+			pollingSemaphore.release()
 		}
 	}
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -43,6 +43,7 @@ task:
     initial-interval-ms: 2000
     max-interval-ms: 10000
     multiplier: 2.0
+    max-concurrent: 5
 
 resilience4j:
   circuitbreaker:

--- a/src/test/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestratorTest.kt
+++ b/src/test/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestratorTest.kt
@@ -2,6 +2,8 @@ package org.sampletask.foreign_api_sample.task.service
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
@@ -22,6 +24,7 @@ import org.sampletask.foreign_api_sample.task.domain.RecoveryAction
 import org.sampletask.foreign_api_sample.task.domain.Task
 import org.sampletask.foreign_api_sample.task.domain.TaskStatus
 import org.sampletask.foreign_api_sample.task.exception.MockWorkerException
+import java.util.concurrent.atomic.AtomicInteger
 
 @ExtendWith(MockitoExtension::class)
 class TaskOrchestratorTest {
@@ -54,6 +57,7 @@ class TaskOrchestratorTest {
 				initialIntervalMs = 10,
 				maxIntervalMs = 50,
 				multiplier = 2.0,
+				maxConcurrentPolling = 2,
 			)
 	}
 
@@ -217,6 +221,49 @@ class TaskOrchestratorTest {
 				assertThat(task.status).isEqualTo(TaskStatus.COMPLETED)
 				assertThat(task.result).isEqualTo("result-data")
 				verify(mockWorkerClient, times(3)).getJobStatus("job-123")
+			}
+		}
+	}
+
+	@Nested
+	@Suppress("ClassName")
+	inner class 동시_폴링_제한 {
+
+		@Test
+		fun `maxConcurrentPolling_초과_동시_폴링_불가`() {
+			runTest {
+				val concurrentCount = AtomicInteger(0)
+				val maxObserved = AtomicInteger(0)
+
+				val tasks = (1L..3L).map { id ->
+					createTask(id = id)
+				}
+
+				tasks.forEach { task ->
+					whenever(taskService.getTask(task.id)).thenReturn(task)
+				}
+				whenever(taskService.updateTask(any())).thenAnswer { it.arguments[0] as Task }
+				whenever(mockWorkerClient.submitProcess(any())).thenAnswer {
+					ProcessResponse("job-shared")
+				}
+
+				whenever(mockWorkerClient.getJobStatus("job-shared")).thenAnswer {
+					val current = concurrentCount.incrementAndGet()
+					maxObserved.updateAndGet { max -> maxOf(max, current) }
+					Thread.sleep(10)
+					concurrentCount.decrementAndGet()
+					JobStatusResponse(jobId = "job-shared", status = "COMPLETED", result = "result")
+				}
+
+				val deferred = tasks.map { task ->
+					async { orchestrator.processTask(task) }
+				}
+				deferred.awaitAll()
+
+				assertThat(maxObserved.get()).isLessThanOrEqualTo(2)
+				tasks.forEach { task ->
+					assertThat(task.status).isEqualTo(TaskStatus.COMPLETED)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## 목표
Semaphore 기반 동시 폴링 수 제한

## 작업 항목
- application.yaml에 `task.polling.max-concurrent` 설정 추가
- TaskOrchestrator에 `Semaphore` 도입하여 `pollForResult` 동시 실행 수 제한
- 동시 폴링 제한 검증 테스트 추가 (`maxConcurrentPolling=2`로 3개 작업 실행)

Closes #51