### PR TITLE
[feat] feat/006-02-hikaricp-pool-config

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,12 @@ spring:
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 5
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
 
   jpa:
     hibernate:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -2,6 +2,12 @@ spring:
   datasource:
     url: ${TEST_DATASOURCE_URL:jdbc:tc:mysql:8.0:///foreign_api_sample}
     driver-class-name: ${TEST_DATASOURCE_DRIVER:org.testcontainers.jdbc.ContainerDatabaseDriver}
+    hikari:
+      maximum-pool-size: 5
+      minimum-idle: 2
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
 
   jpa:
     hibernate:


### PR DESCRIPTION
## 목표
HikariCP 커넥션 풀을 명시적으로 설정하여 운영 환경에서의 DB 커넥션 관리를 개선한다.

## 변경 사항
- `application.yaml`: HikariCP 설정 추가 (pool-size: 10, min-idle: 5, timeout 등)
- `test/application.yaml`: 테스트용 HikariCP 설정 추가 (pool-size: 5, min-idle: 2)

Closes #53