### PR TITLE
[feat] feat/006-08-polling-max-timeout

### DIFF
--- a/src/main/kotlin/org/sampletask/foreign_api_sample/common/ErrorCode.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/common/ErrorCode.kt
@@ -11,6 +11,7 @@ enum class ErrorCode(val code: String, val messageTemplate: String) {
 	MISSING_HEADER("MISSING_HEADER", "%s"),
 	BAD_REQUEST("BAD_REQUEST", "%s"),
 	INTERNAL_ERROR("INTERNAL_ERROR", "%s"),
+	POLLING_TIMEOUT("POLLING_TIMEOUT", "폴링 최대 시간 초과: %s"),
 	UNKNOWN_TASK_STATUS("UNKNOWN_TASK_STATUS", "Unknown TaskStatus code: %s"),
 	;
 

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestrator.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestrator.kt
@@ -1,9 +1,11 @@
 package org.sampletask.foreign_api_sample.task.service
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.withTimeout
 import org.sampletask.foreign_api_sample.common.ErrorCode
 import org.sampletask.foreign_api_sample.task.client.MockWorkerClient
 import org.sampletask.foreign_api_sample.task.domain.RecoveryAction
@@ -24,6 +26,7 @@ class TaskOrchestrator(
 	@Value("\${task.polling.max-interval-ms:10000}") private val maxIntervalMs: Long,
 	@Value("\${task.polling.multiplier:2.0}") private val multiplier: Double,
 	@Value("\${task.polling.max-concurrent:5}") private val maxConcurrentPolling: Int,
+	@Value("\${task.polling.max-total-duration-ms:300000}") private val maxTotalDurationMs: Long,
 ) {
 	private val log = LoggerFactory.getLogger(javaClass)
 	private val pollingSemaphore = Semaphore(maxConcurrentPolling)
@@ -67,35 +70,39 @@ class TaskOrchestrator(
 
 		pollingSemaphore.acquire()
 		try {
-			while (true) {
-				val jitter = intervalMs * (0.5 + Math.random() * 0.5)
-				delay(jitter.toLong())
+			withTimeout(maxTotalDurationMs) {
+				while (true) {
+					val jitter = intervalMs * (0.5 + Math.random() * 0.5)
+					delay(jitter.toLong())
 
-				try {
-					val status = mockWorkerClient.getJobStatus(jobId)
+					try {
+						val status = mockWorkerClient.getJobStatus(jobId)
 
-					when (status.status) {
-						"COMPLETED" -> {
-							val current = taskService.getTask(taskId)
-							current.result = status.result
-							current.transitionTo(TaskStatus.COMPLETED)
-							taskService.updateTask(current)
-							log.info("작업 {} 완료", taskId)
-							return
+						when (status.status) {
+							"COMPLETED" -> {
+								val current = taskService.getTask(taskId)
+								current.result = status.result
+								current.transitionTo(TaskStatus.COMPLETED)
+								taskService.updateTask(current)
+								log.info("작업 {} 완료", taskId)
+								return@withTimeout
+							}
+							"FAILED" -> {
+								failTask(taskId, status.errorCode, status.errorMessage)
+								return@withTimeout
+							}
+							else -> {
+								intervalMs = (intervalMs * multiplier).toLong().coerceAtMost(maxIntervalMs)
+							}
 						}
-						"FAILED" -> {
-							failTask(taskId, status.errorCode, status.errorMessage)
-							return
-						}
-						else -> {
-							intervalMs = (intervalMs * multiplier).toLong().coerceAtMost(maxIntervalMs)
-						}
+					} catch (e: MockWorkerException) {
+						handleError(taskId, e)
+						return@withTimeout
 					}
-				} catch (e: MockWorkerException) {
-					handleError(taskId, e)
-					return
 				}
 			}
+		} catch (e: TimeoutCancellationException) {
+			failTask(taskId, ErrorCode.POLLING_TIMEOUT.code, ErrorCode.POLLING_TIMEOUT.message(taskId))
 		} finally {
 			pollingSemaphore.release()
 		}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -44,6 +44,7 @@ task:
     max-interval-ms: 10000
     multiplier: 2.0
     max-concurrent: 5
+    max-total-duration-ms: 300000
 
 resilience4j:
   circuitbreaker:

--- a/src/test/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestratorTest.kt
+++ b/src/test/kotlin/org/sampletask/foreign_api_sample/task/service/TaskOrchestratorTest.kt
@@ -58,6 +58,7 @@ class TaskOrchestratorTest {
 				maxIntervalMs = 50,
 				multiplier = 2.0,
 				maxConcurrentPolling = 2,
+				maxTotalDurationMs = 500,
 			)
 	}
 
@@ -223,6 +224,30 @@ class TaskOrchestratorTest {
 				assertThat(task.status).isEqualTo(TaskStatus.COMPLETED)
 				assertThat(task.result).isEqualTo("result-data")
 				verify(mockWorkerClient, times(3)).getJobStatus("job-123")
+			}
+		}
+	}
+
+	@Nested
+	@Suppress("ClassName")
+	inner class 폴링_타임아웃 {
+
+		@Test
+		fun `최대_폴링_시간_초과_시_FAILED_전이`() {
+			runTest {
+				val task = createTask()
+
+				whenever(taskService.getTask(1L)).thenReturn(task)
+				whenever(taskService.updateTask(any())).thenAnswer { it.arguments[0] as Task }
+				whenever(mockWorkerClient.submitProcess(any())).thenReturn(ProcessResponse("job-123"))
+				whenever(mockWorkerClient.getJobStatus("job-123")).thenReturn(
+					JobStatusResponse(jobId = "job-123", status = "PROCESSING"),
+				)
+
+				orchestrator.processTask(task)
+
+				assertThat(task.status).isEqualTo(TaskStatus.FAILED)
+				assertThat(task.errorCode).isEqualTo("POLLING_TIMEOUT")
 			}
 		}
 	}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -27,3 +27,4 @@ task:
   polling:
     initial-interval-ms: 100
     max-interval-ms: 500
+    max-total-duration-ms: 5000


### PR DESCRIPTION
## 목표
pollForResult에 최대 폴링 시간 제한을 추가하여 무한 폴링을 방지한다.

## 변경 사항
- `TaskOrchestrator.kt`: `maxTotalDurationMs` 설정 주입, `withTimeout`으로 폴링 루프 래핑
- `ErrorCode.kt`: `POLLING_TIMEOUT` 에러 코드 추가
- `application.yaml`: `task.polling.max-total-duration-ms: 300000` (5분) 설정 추가
- `test/application.yaml`: 테스트용 짧은 타임아웃 (5000ms) 설정
- `TaskOrchestratorTest.kt`: 타임아웃 초과 시 FAILED 전이 테스트 추가

Closes #72