### PR TITLE
[feat] feat/006-06-recovery-fire-and-forget

### DIFF
--- a/src/main/kotlin/org/sampletask/foreign_api_sample/common/ErrorCode.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/common/ErrorCode.kt
@@ -13,6 +13,7 @@ enum class ErrorCode(val code: String, val messageTemplate: String) {
 	BAD_REQUEST("BAD_REQUEST", "%s"),
 	INTERNAL_ERROR("INTERNAL_ERROR", "%s"),
 	POLLING_TIMEOUT("POLLING_TIMEOUT", "폴링 최대 시간 초과: %s"),
+	RECOVERY_FAILED("RECOVERY_FAILED", "작업 복구 실패: %s"),
 	UNKNOWN_TASK_STATUS("UNKNOWN_TASK_STATUS", "Unknown TaskStatus code: %s"),
 	;
 

--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/service/TaskRecoveryService.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/service/TaskRecoveryService.kt
@@ -2,6 +2,7 @@ package org.sampletask.foreign_api_sample.task.service
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import org.sampletask.foreign_api_sample.common.ErrorCode
 import org.sampletask.foreign_api_sample.task.client.MockWorkerClient
 import org.sampletask.foreign_api_sample.task.domain.RecoveryAction
 import org.sampletask.foreign_api_sample.task.domain.Task
@@ -52,6 +53,17 @@ class TaskRecoveryService(
 		}
 	}
 
+	private fun failTask(task: Task, errorMessage: String?) {
+		try {
+			task.errorCode = ErrorCode.RECOVERY_FAILED.code
+			task.errorMessage = errorMessage
+			task.transitionTo(TaskStatus.FAILED)
+			taskService.updateTask(task)
+		} catch (updateEx: Exception) {
+			log.error("작업 {} FAILED 전이 실패", task.id, updateEx)
+		}
+	}
+
 	private fun recoverProcessingTask(task: Task) {
 		if (task.externalJobId != null) {
 			scope.launch {
@@ -84,12 +96,12 @@ class TaskRecoveryService(
 						taskService.updateTask(task)
 						taskOrchestrator.submitAsync(task)
 					} else {
-						log.error("작업 {} 복구 중 오류: {}", task.id, e.message)
-						taskOrchestrator.submitAsync(task)
+						log.error("작업 {} 복구 실패 - FAILED 전이", task.id, e)
+						failTask(task, e.message)
 					}
 				} catch (e: Exception) {
-					log.error("작업 {} 복구 중 예상치 못한 오류: {}", task.id, e.message, e)
-					taskOrchestrator.submitAsync(task)
+					log.error("작업 {} 복구 실패 - FAILED 전이", task.id, e)
+					failTask(task, e.message)
 				}
 			}
 		} else {

--- a/src/test/kotlin/org/sampletask/foreign_api_sample/task/service/TaskRecoveryServiceTest.kt
+++ b/src/test/kotlin/org/sampletask/foreign_api_sample/task/service/TaskRecoveryServiceTest.kt
@@ -172,16 +172,38 @@ class TaskRecoveryServiceTest {
 		}
 
 		@Test
-		fun `외부_조회_기타_오류_시_폴링_재개`() {
+		fun `외부_조회_기타_오류_시_FAILED_전이`() {
 			runTest {
 				val entity = createEntity(id = 7L, status = TaskStatus.PROCESSING, externalJobId = "job-7")
 				whenever(taskRepository.findAllByStatusIn(any())).thenReturn(listOf(entity))
+				whenever(taskService.updateTask(any())).thenAnswer { it.arguments[0] }
 				whenever(mockWorkerClient.getJobStatus("job-7"))
 					.thenThrow(MockWorkerException(500, "Server Error", RecoveryAction.RETRY))
 
 				recoveryService.recoverTasks()
 
-				verify(taskOrchestrator).submitAsync(any(), anyOrNull())
+				verify(taskService).updateTask(
+					org.mockito.kotlin.argThat { status == TaskStatus.FAILED && errorCode == "RECOVERY_FAILED" },
+				)
+				verify(taskOrchestrator, never()).submitAsync(any(), anyOrNull())
+			}
+		}
+
+		@Test
+		fun `복구_중_예상치_못한_예외_시_FAILED_전이`() {
+			runTest {
+				val entity = createEntity(id = 8L, status = TaskStatus.PROCESSING, externalJobId = "job-8")
+				whenever(taskRepository.findAllByStatusIn(any())).thenReturn(listOf(entity))
+				whenever(taskService.updateTask(any())).thenAnswer { it.arguments[0] }
+				whenever(mockWorkerClient.getJobStatus("job-8"))
+					.thenThrow(RuntimeException("unexpected error"))
+
+				recoveryService.recoverTasks()
+
+				verify(taskService).updateTask(
+					org.mockito.kotlin.argThat { status == TaskStatus.FAILED && errorCode == "RECOVERY_FAILED" },
+				)
+				verify(taskOrchestrator, never()).submitAsync(any(), anyOrNull())
 			}
 		}
 	}


### PR DESCRIPTION
## 목표
TaskRecoveryService의 fire-and-forget 코루틴 예외 처리를 강화하여 복구 실패 시 작업 누락을 방지한다.

## 변경 사항
- `TaskRecoveryService.kt`: 복구 실패 시 submitAsync 대신 FAILED 전이로 안전하게 처리
- `ErrorCode.kt`: `RECOVERY_FAILED` 에러 코드 추가
- `TaskRecoveryServiceTest.kt`: 기타 오류 시 FAILED 전이 검증, 예상치 못한 예외 시 FAILED 전이 테스트 추가

Closes #71