### PR TITLE
[feat] feat/006-09-apikey-concurrent-reissue

### DIFF
--- a/src/main/kotlin/org/sampletask/foreign_api_sample/task/client/ApiKeyManager.kt
+++ b/src/main/kotlin/org/sampletask/foreign_api_sample/task/client/ApiKeyManager.kt
@@ -1,5 +1,7 @@
 package org.sampletask.foreign_api_sample.task.client
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.sampletask.foreign_api_sample.task.client.request.IssueKeyRequest
 import org.sampletask.foreign_api_sample.task.client.response.IssueKeyResponse
 import org.sampletask.foreign_api_sample.task.exception.ApiKeyUnavailableException
@@ -10,7 +12,6 @@ import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.awaitBody
-import java.util.concurrent.atomic.AtomicBoolean
 
 @Component
 class ApiKeyManager(
@@ -24,7 +25,7 @@ class ApiKeyManager(
 	private var _apiKey: String? = null
 	val apiKey: String? get() = _apiKey
 
-	private val reissueLock = AtomicBoolean(false)
+	private val reissueMutex = Mutex()
 
 	@EventListener(ApplicationReadyEvent::class)
 	fun onApplicationReady() {
@@ -43,12 +44,12 @@ class ApiKeyManager(
 	}
 
 	suspend fun reissueApiKey() {
-		if (!reissueLock.compareAndSet(false, true)) {
-			log.debug("API Key 재발급이 이미 진행 중입니다")
-			return
-		}
+		reissueMutex.withLock {
+			if (_apiKey != null) {
+				log.debug("API Key가 이미 재발급되었습니다")
+				return
+			}
 
-		try {
 			repeat(MAX_REISSUE_ATTEMPTS) { attempt ->
 				try {
 					issueApiKey()
@@ -63,8 +64,6 @@ class ApiKeyManager(
 					}
 				}
 			}
-		} finally {
-			reissueLock.set(false)
 		}
 	}
 

--- a/src/test/kotlin/org/sampletask/foreign_api_sample/task/client/ApiKeyManagerTest.kt
+++ b/src/test/kotlin/org/sampletask/foreign_api_sample/task/client/ApiKeyManagerTest.kt
@@ -3,13 +3,17 @@ package org.sampletask.foreign_api_sample.task.client
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.sampletask.foreign_api_sample.task.exception.ApiKeyUnavailableException
 import org.springframework.web.reactive.function.client.WebClient
@@ -80,5 +84,34 @@ class ApiKeyManagerTest {
 		assertThatThrownBy {
 			kotlinx.coroutines.runBlocking { apiKeyManager.reissueApiKey() }
 		}.isInstanceOf(ApiKeyUnavailableException::class.java)
+	}
+
+	@Nested
+	@Suppress("ClassName")
+	inner class 동시성_테스트 {
+
+		@Test
+		fun `동시_10개_코루틴_reissueApiKey_호출_시_실제_발급_1회`() {
+			runTest {
+				wireMockServer.stubFor(
+					post(urlEqualTo("/mock/auth/issue-key"))
+						.willReturn(
+							aResponse()
+								.withStatus(200)
+								.withHeader("Content-Type", "application/json")
+								.withBody("""{"apiKey": "concurrent-key"}"""),
+						),
+				)
+
+				val deferred = (1..10).map {
+					async { apiKeyManager.reissueApiKey() }
+				}
+				deferred.awaitAll()
+
+				assertThat(apiKeyManager.apiKey).isEqualTo("concurrent-key")
+				// 첫 번째 코루틴이 발급 후 나머지는 double-check로 스킵
+				wireMockServer.verify(1, postRequestedFor(urlEqualTo("/mock/auth/issue-key")))
+			}
+		}
 	}
 }


### PR DESCRIPTION
## 목표
ApiKeyManager의 AtomicBoolean을 Mutex로 교체하여 동시 호출자가 대기 후 double-check으로 불필요한 재발급을 방지한다.

## 변경 사항
- `ApiKeyManager.kt`: AtomicBoolean → Mutex 교체, double-check 패턴 적용
- `ApiKeyManagerTest.kt`: 동시 10개 코루틴에서 reissueApiKey() 호출 시 1회만 실제 발급되는지 테스트 추가

Closes #73